### PR TITLE
Fix doc comments for restitution, so markdown doesn't turn ">1" into a blockquote

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -774,8 +774,8 @@ function Sprite(_x, _y, _w, _h) {
   * Coefficient of restitution. The velocity lost after bouncing.
   * 1: perfectly elastic, no energy is lost
   * 0: perfectly inelastic, no bouncing
-  * <1: inelastic, this is the most common in nature
-  * >1: hyper elastic, energy is increased like in a pinball bumper
+  * less than 1: inelastic, this is the most common in nature
+  * greater than 1: hyper elastic, energy is increased like in a pinball bumper
   *
   * @property restitution
   * @type {Number}


### PR DESCRIPTION
Since markdown is apparently available, I'd thought of making it into a list, but I don't know what doc generation/rendering tool is being used, so I figured this is safer.