### PR TITLE
Show friendly error if p5 is in instance mode

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -62,6 +62,8 @@ p5.prototype.allSprites = new Group();
    */
 
 p5.prototype.createSprite = function(x, y, width, height) {
+  this._ensureInGlobalMode();
+
   var s = new Sprite(x, y, width, height);
   s.depth = allSprites.maxDepth()+1;
   allSprites.add(s);
@@ -193,6 +195,8 @@ p5.prototype.drawSprite = function(sprite) {
 * @param {Sprite} sprite Sprite to be displayed
 */
 p5.prototype.loadAnimation = function() {
+  this._ensureInGlobalMode();
+
   return construct(Animation, arguments);
 }
 
@@ -617,6 +621,21 @@ now = Date.now();
 deltaTime = ((now - then) / 1000)/INTERVAL_60; // seconds since last frame
 }
 */
+
+p5.prototype._ensureInGlobalMode = function() {
+  // Unfortunately, p5.play doesn't currently support p5 instance mode.
+  // Instead of continuing execution and eventually throwing when some
+  // global property isn't found, we'll throw an exception with a
+  // helpful (if disappointing) message.
+  //
+  // For more information, see:
+  // https://github.com/molleindustria/p5.play/issues/12
+
+  if (!this._isGlobal) {
+    throw new Error("Unfortunately, p5.play does not yet support p5 " +
+                    "instance mode.");
+  }
+};
 
 }));
 


### PR DESCRIPTION
This is a temporary workaround for #12 that throws a friendly (albeit disappointing) error in the most common p5.play entrypoints if p5 is not in global mode.

I'd like to add this for now until I can get my head around how much work will be involved in making p5.play support instance mode.