### PR TITLE
Light documentation and code cleanup

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -226,9 +226,16 @@ p5.prototype.animation = function(anim, x, y) {
 //variable to detect instant presses
 var keyStates = {};
 var mouseStates = {};
+
+/** @typedef {number} KeyState */
+
+/** @type {KeyState} */
 var KEY_IS_UP = 0;
+/** @type {KeyState} */
 var KEY_WENT_DOWN = 1;
+/** @type {KeyState} */
 var KEY_IS_DOWN = 2;
+/** @type {KeyState} */
 var KEY_WENT_UP = 3;
 
 
@@ -242,23 +249,7 @@ var KEY_WENT_UP = 3;
 * @return {Boolean} True if the key was pressed
 */
 p5.prototype.keyWentDown = function(key) {
-  var keyCode;
-
-  if(typeof key == "string")
-    keyCode = KEY[key.toUpperCase()];
-  else
-    keyCode = key;
-
-  //if undefined start checking it
-  if(keyStates[keyCode]==undefined)
-  {
-    if(keyIsDown(keyCode))
-      keyStates[keyCode] = KEY_IS_DOWN;
-    else
-      keyStates[keyCode] = KEY_IS_UP;
-  }
-
-  return (keyStates[keyCode] == KEY_WENT_DOWN);
+  return this.isKeyInState(key, KEY_WENT_DOWN);
 }
 
 
@@ -272,24 +263,7 @@ p5.prototype.keyWentDown = function(key) {
 * @return {Boolean} True if the key was released
 */
 p5.prototype.keyWentUp = function(key) {
-
-  var keyCode;
-
-  if(typeof key == "string")
-    keyCode = KEY[key.toUpperCase()];
-  else
-    keyCode = key;
-
-  //if undefined start checking it
-  if(keyStates[keyCode]===undefined)
-  {
-    if(keyIsDown(key))
-      keyStates[keyCode] = KEY_IS_DOWN;
-    else
-      keyStates[keyCode] = KEY_IS_UP;
-  }
-
-  return (keyStates[keyCode] == KEY_WENT_UP);
+  return this.isKeyInState(key, KEY_WENT_UP);
 }
 
 /**
@@ -301,7 +275,20 @@ p5.prototype.keyWentUp = function(key) {
 * @return {Boolean} True if the key is down
 */
 p5.prototype.keyDown = function(key) {
+  return this.isKeyInState(key, KEY_IS_DOWN);
+}
 
+/**
+* Detects if a key is in the given state during the last cycle.
+* Helper method encapsulating common key state logic; it may be preferable
+* to call keyDown or other methods directly.
+*
+* @method isKeyInState
+* @param {Number|String} key Key code or character
+* @param {KeyState} state Key state to check against
+* @return {Boolean} True if the key is in the given state
+*/
+p5.prototype.isKeyInState = function(key, state) {
   var keyCode;
 
   if(typeof key == "string")
@@ -318,7 +305,7 @@ p5.prototype.keyDown = function(key) {
       keyStates[keyCode] = KEY_IS_UP;
   }
 
-  return (keyStates[keyCode] == KEY_IS_DOWN);
+  return (keyStates[keyCode] == state);
 }
 
 /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -313,26 +313,11 @@ p5.prototype.isKeyInState = function(key, state) {
 * Combines mouseIsPressed and mouseButton of p5
 *
 * @method mouseDown
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button is down
 */
 p5.prototype.mouseDown = function(buttonCode) {
-
-  if(buttonCode == undefined)
-    buttonCode = LEFT;
-  else
-    buttonCode = buttonCode;
-
-  //undefined = not tracked yet, start tracking
-  if(mouseStates[buttonCode]===undefined)
-  {
-  if(mouseIsPressed && mouseButton == buttonCode)
-    mouseStates[buttonCode] = KEY_IS_DOWN;
-  else
-    mouseStates[buttonCode] = KEY_IS_UP;
-  }
-
-  return (mouseStates[buttonCode] == KEY_IS_DOWN);
+  return this.isMouseButtonInState(buttonCode, KEY_IS_DOWN);
 }
 
 /**
@@ -340,26 +325,11 @@ p5.prototype.mouseDown = function(buttonCode) {
 * Combines mouseIsPressed and mouseButton of p5
 *
 * @method mouseUp
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button is up
 */
 p5.prototype.mouseUp = function(buttonCode) {
-
-  if(buttonCode == undefined)
-    buttonCode = LEFT;
-  else
-    buttonCode = buttonCode;
-
-  //undefined = not tracked yet, start tracking
-  if(mouseStates[buttonCode]===undefined)
-  {
-  if(mouseIsPressed && mouseButton == buttonCode)
-    mouseStates[buttonCode] = KEY_IS_DOWN;
-  else
-    mouseStates[buttonCode] = KEY_IS_UP;
-  }
-
-  return (mouseStates[buttonCode] == KEY_IS_UP);
+  return this.isMouseButtonInState(buttonCode, KEY_IS_UP);
 }
 
 /**
@@ -367,26 +337,11 @@ p5.prototype.mouseUp = function(buttonCode) {
 * It can be used to trigger events once, to be checked in the draw cycle
 *
 * @method mouseWentUp
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button was just released
 */
 p5.prototype.mouseWentUp = function(buttonCode) {
-
-  if(buttonCode == undefined)
-    buttonCode = LEFT;
-  else
-    buttonCode = buttonCode;
-
-  //undefined = not tracked yet, start tracking
-  if(mouseStates[buttonCode]===undefined)
-  {
-  if(mouseIsPressed && mouseButton == buttonCode)
-    mouseStates[buttonCode] = KEY_IS_DOWN;
-  else
-    mouseStates[buttonCode] = KEY_IS_UP;
-  }
-
-  return (mouseStates[buttonCode] == KEY_WENT_UP);
+  return this.isMouseButtonInState(buttonCode, KEY_WENT_UP);
 }
 
 
@@ -395,11 +350,23 @@ p5.prototype.mouseWentUp = function(buttonCode) {
 * It can be used to trigger events once, to be checked in the draw cycle
 *
 * @method mouseWentDown
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button was just pressed
 */
 p5.prototype.mouseWentDown = function(buttonCode) {
+  return this.isMouseButtonInState(buttonCode, KEY_WENT_DOWN);
+}
 
+/**
+* Detects if a mouse button is in the given state during the last cycle.
+* Helper method encapsulating common mouse button state logic; it may be
+* preferable to call mouseWentUp, etc, directly.
+*
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+* @param {KeyState} state
+* @returns {boolean} True if the button was in the given state
+*/
+p5.prototype.isMouseButtonInState = function(buttonCode, state) {
   if(buttonCode == undefined)
     buttonCode = LEFT;
   else
@@ -414,7 +381,7 @@ p5.prototype.mouseWentDown = function(buttonCode) {
     mouseStates[buttonCode] = KEY_IS_UP;
   }
 
-  return (mouseStates[buttonCode] == KEY_WENT_DOWN);
+  return (mouseStates[buttonCode] == state);
 }
 
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -710,7 +710,7 @@ function Sprite(_x, _y, _w, _h) {
   *
   * @property friction
   * @type {Number}
-  * @default -1
+  * @default 1
   */
   this.friction = 1;
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -939,7 +939,7 @@ function Sprite(_x, _y, _w, _h) {
   this.originalHeight = this.height;
 
   /**
-  * False if the sprite has been removed.
+  * True if the sprite has been removed.
   *
   * @property removed
   * @type {Boolean}

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -509,7 +509,7 @@ p5.prototype.KEY = {
     '9NUMPAD': 105,
     'MULTIPLY': 106,
     'PLUS': 107,
-    'MINUT': 109,
+    'MINUS': 109,
     'DOT': 110,
     'SLASH1': 111,
     'F1': 112,


### PR DESCRIPTION
I was reviewing the library today and spotted some low-hanging fruit fixes, so I ran with it :grin:.

* The collection of keycodes had `MINUS` misspelled as `MINUT`
* The `friction` property of `Sprite` had a documented default of -1, but it's real default was 1.
* The `removed` property of `Sprite` said "False when the sprite has been removed" which is the opposite of what it means.
* There was a great deal of duplicate code in the key and mouse state queries, so I extracted it.