### PR TITLE
Documentation fixes

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -710,7 +710,7 @@ function Sprite(_x, _y, _w, _h) {
   *
   * @property friction
   * @type {Number}
-  * @default -1
+  * @default 1
   */
   this.friction = 1;
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -939,7 +939,7 @@ function Sprite(_x, _y, _w, _h) {
   this.originalHeight = this.height;
 
   /**
-  * False if the sprite has been removed.
+  * True if the sprite has been removed.
   *
   * @property removed
   * @type {Boolean}


### PR DESCRIPTION
Broken out from PR #26:

* The friction property of Sprite had a documented default of -1, but it's real default was 1.
* The removed property of Sprite said "False when the sprite has been removed" which is the opposite of what it means.