### PR TITLE
Deduplicate key- and mouse-state checks

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -321,9 +321,15 @@ defineLazyP5Property('_p5play', function() {
   };
 });
 
+/** @typedef {number} KeyState */
+
+/** @type {KeyState} */
 var KEY_IS_UP = 0;
+/** @type {KeyState} */
 var KEY_WENT_DOWN = 1;
+/** @type {KeyState} */
 var KEY_IS_DOWN = 2;
+/** @type {KeyState} */
 var KEY_WENT_UP = 3;
 
 
@@ -337,24 +343,7 @@ var KEY_WENT_UP = 3;
 * @return {Boolean} True if the key was pressed
 */
 p5.prototype.keyWentDown = function(key) {
-  var keyCode;
-  var keyStates = this._p5play.keyStates;
-
-  if(typeof key == "string")
-    keyCode = this._keyCodeFromAlias(key);
-  else
-    keyCode = key;
-
-  //if undefined start checking it
-  if(keyStates[keyCode]==undefined)
-  {
-    if(this.keyIsDown(keyCode))
-      keyStates[keyCode] = KEY_IS_DOWN;
-    else
-      keyStates[keyCode] = KEY_IS_UP;
-  }
-
-  return (keyStates[keyCode] == KEY_WENT_DOWN);
+  return this.isKeyInState(key, KEY_WENT_DOWN);
 }
 
 
@@ -368,24 +357,7 @@ p5.prototype.keyWentDown = function(key) {
 * @return {Boolean} True if the key was released
 */
 p5.prototype.keyWentUp = function(key) {
-  var keyCode;
-  var keyStates = this._p5play.keyStates;
-
-  if(typeof key == "string")
-    keyCode = this._keyCodeFromAlias(key);
-  else
-    keyCode = key;
-
-  //if undefined start checking it
-  if(keyStates[keyCode]===undefined)
-  {
-    if(this.keyIsDown(keyCode))
-      keyStates[keyCode] = KEY_IS_DOWN;
-    else
-      keyStates[keyCode] = KEY_IS_UP;
-  }
-
-  return (keyStates[keyCode] == KEY_WENT_UP);
+  return this.isKeyInState(key, KEY_WENT_UP);
 }
 
 /**
@@ -397,6 +369,20 @@ p5.prototype.keyWentUp = function(key) {
 * @return {Boolean} True if the key is down
 */
 p5.prototype.keyDown = function(key) {
+  return this.isKeyInState(key, KEY_IS_DOWN);
+}
+
+/**
+* Detects if a key is in the given state during the last cycle.
+* Helper method encapsulating common key state logic; it may be preferable
+* to call keyDown or other methods directly.
+*
+* @method isKeyInState
+* @param {Number|String} key Key code or character
+* @param {KeyState} state Key state to check against
+* @return {Boolean} True if the key is in the given state
+*/
+p5.prototype.isKeyInState = function(key, state) {
   var keyCode;
   var keyStates = this._p5play.keyStates;
 
@@ -418,7 +404,7 @@ p5.prototype.keyDown = function(key) {
       keyStates[keyCode] = KEY_IS_UP;
   }
 
-  return (keyStates[keyCode] == KEY_IS_DOWN);
+  return (keyStates[keyCode] == state);
 }
 
 /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -412,27 +412,11 @@ p5.prototype.isKeyInState = function(key, state) {
 * Combines mouseIsPressed and mouseButton of p5
 *
 * @method mouseDown
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button is down
 */
 p5.prototype.mouseDown = function(buttonCode) {
-  var mouseStates = this._p5play.mouseStates;
-
-  if(buttonCode == undefined)
-    buttonCode = this.LEFT;
-  else
-    buttonCode = buttonCode;
-
-  //undefined = not tracked yet, start tracking
-  if(mouseStates[buttonCode]===undefined)
-  {
-  if(this.mouseIsPressed && this.mouseButton == buttonCode)
-    mouseStates[buttonCode] = KEY_IS_DOWN;
-  else
-    mouseStates[buttonCode] = KEY_IS_UP;
-  }
-
-  return (mouseStates[buttonCode] == KEY_IS_DOWN);
+  return this.isMouseButtonInState(buttonCode, KEY_IS_DOWN);
 }
 
 /**
@@ -440,27 +424,11 @@ p5.prototype.mouseDown = function(buttonCode) {
 * Combines mouseIsPressed and mouseButton of p5
 *
 * @method mouseUp
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button is up
 */
 p5.prototype.mouseUp = function(buttonCode) {
-  var mouseStates = this._p5play.mouseStates;
-
-  if(buttonCode == undefined)
-    buttonCode = this.LEFT;
-  else
-    buttonCode = buttonCode;
-
-  //undefined = not tracked yet, start tracking
-  if(mouseStates[buttonCode]===undefined)
-  {
-  if(this.mouseIsPressed && this.mouseButton == buttonCode)
-    mouseStates[buttonCode] = KEY_IS_DOWN;
-  else
-    mouseStates[buttonCode] = KEY_IS_UP;
-  }
-
-  return (mouseStates[buttonCode] == KEY_IS_UP);
+  return this.isMouseButtonInState(buttonCode, KEY_IS_UP);
 }
 
 /**
@@ -468,27 +436,11 @@ p5.prototype.mouseUp = function(buttonCode) {
 * It can be used to trigger events once, to be checked in the draw cycle
 *
 * @method mouseWentUp
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button was just released
 */
 p5.prototype.mouseWentUp = function(buttonCode) {
-  var mouseStates = this._p5play.mouseStates;
-
-  if(buttonCode == undefined)
-    buttonCode = this.LEFT;
-  else
-    buttonCode = buttonCode;
-
-  //undefined = not tracked yet, start tracking
-  if(mouseStates[buttonCode]===undefined)
-  {
-  if(this.mouseIsPressed && this.mouseButton == buttonCode)
-    mouseStates[buttonCode] = KEY_IS_DOWN;
-  else
-    mouseStates[buttonCode] = KEY_IS_UP;
-  }
-
-  return (mouseStates[buttonCode] == KEY_WENT_UP);
+  return this.isMouseButtonInState(buttonCode, KEY_WENT_UP);
 }
 
 
@@ -497,10 +449,23 @@ p5.prototype.mouseWentUp = function(buttonCode) {
 * It can be used to trigger events once, to be checked in the draw cycle
 *
 * @method mouseWentDown
-* @param {Number} button Mouse button constant LEFT, RIGHT or CENTER
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @return {Boolean} True if the button was just pressed
 */
 p5.prototype.mouseWentDown = function(buttonCode) {
+  return this.isMouseButtonInState(buttonCode, KEY_WENT_DOWN);
+}
+
+/**
+* Detects if a mouse button is in the given state during the last cycle.
+* Helper method encapsulating common mouse button state logic; it may be
+* preferable to call mouseWentUp, etc, directly.
+*
+* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+* @param {KeyState} state
+* @returns {boolean} True if the button was in the given state
+*/
+p5.prototype.isMouseButtonInState = function(buttonCode, state) {
   var mouseStates = this._p5play.mouseStates;
 
   if(buttonCode == undefined)
@@ -517,7 +482,7 @@ p5.prototype.mouseWentDown = function(buttonCode) {
     mouseStates[buttonCode] = KEY_IS_UP;
   }
 
-  return (mouseStates[buttonCode] == KEY_WENT_DOWN);
+  return (mouseStates[buttonCode] == state);
 }
 
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -343,7 +343,7 @@ var KEY_WENT_UP = 3;
 * @return {Boolean} True if the key was pressed
 */
 p5.prototype.keyWentDown = function(key) {
-  return this.isKeyInState(key, KEY_WENT_DOWN);
+  return this._isKeyInState(key, KEY_WENT_DOWN);
 }
 
 
@@ -357,7 +357,7 @@ p5.prototype.keyWentDown = function(key) {
 * @return {Boolean} True if the key was released
 */
 p5.prototype.keyWentUp = function(key) {
-  return this.isKeyInState(key, KEY_WENT_UP);
+  return this._isKeyInState(key, KEY_WENT_UP);
 }
 
 /**
@@ -369,7 +369,7 @@ p5.prototype.keyWentUp = function(key) {
 * @return {Boolean} True if the key is down
 */
 p5.prototype.keyDown = function(key) {
-  return this.isKeyInState(key, KEY_IS_DOWN);
+  return this._isKeyInState(key, KEY_IS_DOWN);
 }
 
 /**
@@ -377,12 +377,13 @@ p5.prototype.keyDown = function(key) {
 * Helper method encapsulating common key state logic; it may be preferable
 * to call keyDown or other methods directly.
 *
-* @method isKeyInState
+* @method _isKeyInState
 * @param {Number|String} key Key code or character
 * @param {KeyState} state Key state to check against
 * @return {Boolean} True if the key is in the given state
+* @private
 */
-p5.prototype.isKeyInState = function(key, state) {
+p5.prototype._isKeyInState = function(key, state) {
   var keyCode;
   var keyStates = this._p5play.keyStates;
 
@@ -416,7 +417,7 @@ p5.prototype.isKeyInState = function(key, state) {
 * @return {Boolean} True if the button is down
 */
 p5.prototype.mouseDown = function(buttonCode) {
-  return this.isMouseButtonInState(buttonCode, KEY_IS_DOWN);
+  return this._isMouseButtonInState(buttonCode, KEY_IS_DOWN);
 }
 
 /**
@@ -428,7 +429,7 @@ p5.prototype.mouseDown = function(buttonCode) {
 * @return {Boolean} True if the button is up
 */
 p5.prototype.mouseUp = function(buttonCode) {
-  return this.isMouseButtonInState(buttonCode, KEY_IS_UP);
+  return this._isMouseButtonInState(buttonCode, KEY_IS_UP);
 }
 
 /**
@@ -440,7 +441,7 @@ p5.prototype.mouseUp = function(buttonCode) {
 * @return {Boolean} True if the button was just released
 */
 p5.prototype.mouseWentUp = function(buttonCode) {
-  return this.isMouseButtonInState(buttonCode, KEY_WENT_UP);
+  return this._isMouseButtonInState(buttonCode, KEY_WENT_UP);
 }
 
 
@@ -453,7 +454,7 @@ p5.prototype.mouseWentUp = function(buttonCode) {
 * @return {Boolean} True if the button was just pressed
 */
 p5.prototype.mouseWentDown = function(buttonCode) {
-  return this.isMouseButtonInState(buttonCode, KEY_WENT_DOWN);
+  return this._isMouseButtonInState(buttonCode, KEY_WENT_DOWN);
 }
 
 /**
@@ -461,11 +462,13 @@ p5.prototype.mouseWentDown = function(buttonCode) {
 * Helper method encapsulating common mouse button state logic; it may be
 * preferable to call mouseWentUp, etc, directly.
 *
+* @method _isMouseButtonInState
 * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @param {KeyState} state
 * @returns {boolean} True if the button was in the given state
+* @private
 */
-p5.prototype.isMouseButtonInState = function(buttonCode, state) {
+p5.prototype._isMouseButtonInState = function(buttonCode, state) {
   var mouseStates = this._p5play.mouseStates;
 
   if(buttonCode == undefined)


### PR DESCRIPTION
Broken out from PR #26:

Extract common code from the methods that check for key state or mouse button state.

Per your request, I've marked the extracted helper methods as `@private`.  I've also added a leading underscore; I'm not sure what the convention is in this repo; [this method](https://github.com/molleindustria/p5.play/blob/master/lib/p5.play.js#L3523) was the only example I could find of a private method on a prototype.

If you'd prefer that I take these helpers off the prototype entirely I can do so, but that seems like a step away from [supporting instance mode](https://github.com/molleindustria/p5.play/issues/12) since they do depend on some state that's currently global.