### PR TITLE
Deprecate bad key aliases

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -305,9 +305,13 @@ p5.prototype.keyDown = function(key) {
   var keyCode;
 
   if(typeof key == "string")
-    keyCode = KEY[key.toUpperCase()];
+  {
+    keyCode = this.keyCodeFromAlias_(key);
+  }
   else
+  {
     keyCode = key;
+  }
 
   //if undefined start checking it
   if(keyStates[keyCode]===undefined)
@@ -436,9 +440,8 @@ p5.prototype.mouseWentDown = function(buttonCode) {
 * Key.tab = 9
 *
 * @property KEY
-* @type {Group}
+* @type {Object}
 */
-
 p5.prototype.KEY = {
     'BACKSPACE': 8,
     'TAB': 9,
@@ -509,7 +512,7 @@ p5.prototype.KEY = {
     '9NUMPAD': 105,
     'MULTIPLY': 106,
     'PLUS': 107,
-    'MINUT': 109,
+    'MINUS': 109,
     'DOT': 110,
     'SLASH1': 111,
     'F1': 112,
@@ -525,12 +528,46 @@ p5.prototype.KEY = {
     'F11': 122,
     'F12': 123,
     'EQUAL': 187,
-    'COMA': 188,
+    'COMMA': 188,
     'SLASH': 191,
     'BACKSLASH': 220
 }
 
+/**
+ * An object storing deprecated key aliases, which we still support but
+ * should be mapped to valid aliases and generate warnings.
+ *
+ * @property KEY_DEPRECATIONS
+ * @type {Object}
+ */
+p5.prototype.KEY_DEPRECATIONS = {
+  'MINUT': 'MINUS',
+  'COMA': 'COMMA'
+}
 
+/**
+ * Given a string key alias (as defined in the KEY property above), look up
+ * and return the numeric JavaScript key code for that key.  If a deprecated
+ * alias is passed (as defined in the KEY_DEPRECATIONS property) it will be
+ * mapped to a valid key code, but will also generate a warning about use
+ * of the deprecated alias.
+ *
+ * @method keyCodeFromAlias_
+ * @param {!string} alias - a case-insensitive key alias
+ * @returns {number|undefined} a numeric JavaScript key code, or undefined
+ *          if no key code matching the given alias is found.
+ * @private
+ */
+p5.prototype.keyCodeFromAlias_ = function (alias) {
+  alias = alias.toUpperCase();
+  if (this.KEY_DEPRECATIONS[alias]) {
+    this.warn_('Key literal "' + alias + '" is deprecated and may be removed ' +
+      'in a future version of p5.play. ' +
+      'Please use "' + this.KEY_DEPRECATIONS[alias] + '" instead.');
+    alias = this.KEY_DEPRECATIONS[alias];
+  }
+  return this.KEY[alias];
+}
 
 //pre draw: detect keyStates
 p5.prototype.readPresses = function() {
@@ -3990,3 +4027,23 @@ p5.prototype.registerMethod('post', cameraPop);
 //deltaTime
 //p5.prototype.registerMethod('pre', updateDelta);
 
+/**
+ * Log a warning message to the host console, using native `console.warn`
+ * if it is available but falling back on `console.log` if not.  If no
+ * console is availble, this method will fail silently.
+ * @method warn
+ * @param {!string} message
+ */
+p5.prototype.warn_ = function (message) {
+  if(console)
+  {
+    if('function' === typeof console.warn)
+    {
+      console.warn(message);
+    }
+    else if('function' === typeof console.log)
+    {
+      console.log('Warning: ' + message);
+    }
+  }
+}

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -245,7 +245,7 @@ p5.prototype.keyWentDown = function(key) {
   var keyCode;
 
   if(typeof key == "string")
-    keyCode = KEY[key.toUpperCase()];
+    keyCode = this.keyCodeFromAlias_(key);
   else
     keyCode = key;
 
@@ -276,14 +276,14 @@ p5.prototype.keyWentUp = function(key) {
   var keyCode;
 
   if(typeof key == "string")
-    keyCode = KEY[key.toUpperCase()];
+    keyCode = this.keyCodeFromAlias_(key);
   else
     keyCode = key;
 
   //if undefined start checking it
   if(keyStates[keyCode]===undefined)
   {
-    if(keyIsDown(key))
+    if(keyIsDown(keyCode))
       keyStates[keyCode] = KEY_IS_DOWN;
     else
       keyStates[keyCode] = KEY_IS_UP;
@@ -316,7 +316,7 @@ p5.prototype.keyDown = function(key) {
   //if undefined start checking it
   if(keyStates[keyCode]===undefined)
   {
-    if(keyIsDown(key))
+    if(keyIsDown(keyCode))
       keyStates[keyCode] = KEY_IS_DOWN;
     else
       keyStates[keyCode] = KEY_IS_UP;

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,7 @@
     <script src="../examples/lib/p5.js"></script>
     <script src="../lib/p5.play.js"></script>
     <script src="unit/group.js"></script>
+    <script src="unit/keycodes.js"></script>
     <script>
       // p5.play currently only works in global mode, not instance mode,
       // so we'll need to use that.

--- a/test/unit/keycodes.js
+++ b/test/unit/keycodes.js
@@ -72,24 +72,24 @@ describe('keyCodeFromAlias_', function() {
       }
     });
 
-    it("should alias 'MINUT' to 'MINUS'", function() {
+    it("aliases 'MINUT' to 'MINUS'", function() {
       expect(keyCodeFromAlias_('MINUT'))
         .to.equal(keyCodeFromAlias_('MINUS'));
     });
 
-    it("should warn when using MINUT", function () {
+    it("warns when using MINUT", function () {
       keyCodeFromAlias_('MINUT');
       expect(lastConsoleMessage)
         .to.equal('Key literal "MINUT" is deprecated and may be removed in a ' +
                   'future version of p5.play. Please use "MINUS" instead.');
     });
 
-    it("should alias 'COMA' to 'COMMA'", function() {
+    it("aliases 'COMA' to 'COMMA'", function() {
       expect(keyCodeFromAlias_('COMA'))
         .to.equal(keyCodeFromAlias_('COMMA'));
     });
 
-    it("should warn when using COMA", function () {
+    it("warns when using COMA", function () {
       keyCodeFromAlias_('COMA');
       expect(lastConsoleMessage)
         .to.equal('Key literal "COMA" is deprecated and may be removed in a ' +

--- a/test/unit/keycodes.js
+++ b/test/unit/keycodes.js
@@ -1,0 +1,99 @@
+describe('keyCodeFromAlias_', function() {
+  var lastConsoleMessage, originalWarnFunction;
+
+  beforeEach(function () {
+    // Stub p5.prototype.warn_ to hide console output during tests
+    // and allow sensing console output as needed.
+    originalWarnFunction = p5.prototype.warn_;
+    p5.prototype.warn_ = function (msg) {
+      lastConsoleMessage = msg;
+    };
+
+    lastConsoleMessage = undefined;
+  });
+
+  afterEach(function () {
+    // Restore original p5.prototype.warn_ so we don't affect other tests.
+    p5.prototype.warn_ = originalWarnFunction;
+  });
+
+  describe("key aliases", function () {
+    it("maps every alias to a numeric keycode", function () {
+      for (var alias in KEY) {
+        expect(typeof keyCodeFromAlias_(alias)).to.equal('number');
+      }
+    });
+
+    it('is case-insensitive', function () {
+      var upperCaseAlias, lowerCaseAlias, randomCaseAlias;
+      for (var alias in KEY) {
+        upperCaseAlias = alias.toUpperCase();
+        lowerCaseAlias = alias.toLowerCase();
+        randomCaseAlias = alias.split('').map(function (char) {
+          if (Math.random() < 0.5) {
+            return char.toUpperCase();
+          } else {
+            return char.toLowerCase();
+          }
+        }).join('');
+
+        expect(keyCodeFromAlias_(upperCaseAlias))
+          .to.equal(keyCodeFromAlias_(lowerCaseAlias))
+          .to.equal(keyCodeFromAlias_(randomCaseAlias));
+      }
+    });
+
+    it("does not warn when looking up a regular alias", function () {
+      for (var alias in KEY) {
+        keyCodeFromAlias_(alias);
+        expect(lastConsoleMessage).to.be.undefined;
+      }
+    });
+
+    it("maps MINUS to 109", function () {
+      expect(keyCodeFromAlias_('MINUS')).to.equal(109);
+    });
+
+    it("maps COMMA to 188", function () {
+      expect(keyCodeFromAlias_('COMMA')).to.equal(188);
+    });
+  });
+
+  describe("deprecated aliases", function() {
+    it("maps every deprecated alias to a valid key alias", function () {
+      for (var alias in KEY_DEPRECATIONS) {
+        expect(KEY).to.include.keys(KEY_DEPRECATIONS[alias]);
+      }
+    });
+
+    it("does not include any deprecated aliases in key aliases", function () {
+      for (var alias in KEY_DEPRECATIONS) {
+        expect(KEY).to.not.include.keys(alias);
+      }
+    });
+
+    it("should alias 'MINUT' to 'MINUS'", function() {
+      expect(keyCodeFromAlias_('MINUT'))
+        .to.equal(keyCodeFromAlias_('MINUS'));
+    });
+
+    it("should warn when using MINUT", function () {
+      keyCodeFromAlias_('MINUT');
+      expect(lastConsoleMessage)
+        .to.equal('Key literal "MINUT" is deprecated and may be removed in a ' +
+                  'future version of p5.play. Please use "MINUS" instead.');
+    });
+
+    it("should alias 'COMA' to 'COMMA'", function() {
+      expect(keyCodeFromAlias_('COMA'))
+        .to.equal(keyCodeFromAlias_('COMMA'));
+    });
+
+    it("should warn when using COMA", function () {
+      keyCodeFromAlias_('COMA');
+      expect(lastConsoleMessage)
+        .to.equal('Key literal "COMA" is deprecated and may be removed in a ' +
+                  'future version of p5.play. Please use "COMMA" instead.');
+    });
+  });
+});


### PR DESCRIPTION
Broken out from PR #26:

There are some misspelled key aliases in the `KEY` property:

* `MINUT` instead of `MINUS`
* `COMA` instead of `COMMA`

This change corrects the typos, and also introduces a 'deprecated alias' list.  Deprecated aliases are still accepted, but will generate a warning in the browser console when used with a recommendation to change to a corrected alias.

> Key literal "MINUT" is deprecated and may be removed in a future version of p5.play. Please use "MINUS" instead.

This also introduces a set of tests for the new `keyCodeFromAlias_` private lookup helper:

```
  keyCodeFromAlias_
    key aliases
      ✓ maps every alias to a numeric keycode 
      ✓ is case-insensitive 
      ✓ does not warn when looking up a regular alias 
      ✓ maps MINUS to 109 
      ✓ maps COMMA to 188 
    deprecated aliases
      ✓ maps every deprecated alias to a valid key alias 
      ✓ does not include any deprecated aliases in key aliases 
      ✓ aliases 'MINUT' to 'MINUS' 
      ✓ warns when using MINUT 
      ✓ aliases 'COMA' to 'COMMA' 
      ✓ warns when using COMA 
```

Note: I've set up this PR to be independent of #28, but they do have some overlap so I'll need to resolve a conflict on whichever PR we merge second.