### PR TITLE
Follow convention for private method naming and annotation

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -245,7 +245,7 @@ p5.prototype.keyWentDown = function(key) {
   var keyCode;
 
   if(typeof key == "string")
-    keyCode = this.keyCodeFromAlias_(key);
+    keyCode = this._keyCodeFromAlias(key);
   else
     keyCode = key;
 
@@ -276,7 +276,7 @@ p5.prototype.keyWentUp = function(key) {
   var keyCode;
 
   if(typeof key == "string")
-    keyCode = this.keyCodeFromAlias_(key);
+    keyCode = this._keyCodeFromAlias(key);
   else
     keyCode = key;
 
@@ -306,7 +306,7 @@ p5.prototype.keyDown = function(key) {
 
   if(typeof key == "string")
   {
-    keyCode = this.keyCodeFromAlias_(key);
+    keyCode = this._keyCodeFromAlias(key);
   }
   else
   {
@@ -556,16 +556,16 @@ p5.prototype.KEY_DEPRECATIONS = {
  * mapped to a valid key code, but will also generate a warning about use
  * of the deprecated alias.
  *
- * @method keyCodeFromAlias_
+ * @method _keyCodeFromAlias
  * @param {!string} alias - a case-insensitive key alias
  * @returns {number|undefined} a numeric JavaScript key code, or undefined
  *          if no key code matching the given alias is found.
  * @private
  */
-p5.prototype.keyCodeFromAlias_ = function (alias) {
+p5.prototype._keyCodeFromAlias = function (alias) {
   alias = alias.toUpperCase();
   if (this.KEY_DEPRECATIONS[alias]) {
-    this.warn_('Key literal "' + alias + '" is deprecated and may be removed ' +
+    this._warn('Key literal "' + alias + '" is deprecated and may be removed ' +
       'in a future version of p5.play. ' +
       'Please use "' + this.KEY_DEPRECATIONS[alias] + '" instead.');
     alias = this.KEY_DEPRECATIONS[alias];
@@ -663,6 +663,10 @@ deltaTime = ((now - then) / 1000)/INTERVAL_60; // seconds since last frame
 }
 */
 
+/**
+ * @method _ensureInGlobalMode
+ * @private
+ */
 p5.prototype._ensureInGlobalMode = function() {
   // Unfortunately, p5.play doesn't currently support p5 instance mode.
   // Instead of continuing execution and eventually throwing when some
@@ -4035,10 +4039,11 @@ p5.prototype.registerMethod('post', cameraPop);
  * Log a warning message to the host console, using native `console.warn`
  * if it is available but falling back on `console.log` if not.  If no
  * console is available, this method will fail silently.
- * @method warn
+ * @method _warn
  * @param {!string} message
+ * @private
  */
-p5.prototype.warn_ = function (message) {
+p5.prototype._warn = function (message) {
   if(console)
   {
     if('function' === typeof console.warn)

--- a/test/unit/keycodes.js
+++ b/test/unit/keycodes.js
@@ -1,11 +1,11 @@
-describe('keyCodeFromAlias_', function() {
+describe('_keyCodeFromAlias', function() {
   var lastConsoleMessage, originalWarnFunction;
 
   beforeEach(function () {
-    // Stub p5.prototype.warn_ to hide console output during tests
+    // Stub p5.prototype._warn to hide console output during tests
     // and allow sensing console output as needed.
-    originalWarnFunction = p5.prototype.warn_;
-    p5.prototype.warn_ = function (msg) {
+    originalWarnFunction = p5.prototype._warn;
+    p5.prototype._warn = function (msg) {
       lastConsoleMessage = msg;
     };
 
@@ -13,14 +13,14 @@ describe('keyCodeFromAlias_', function() {
   });
 
   afterEach(function () {
-    // Restore original p5.prototype.warn_ so we don't affect other tests.
-    p5.prototype.warn_ = originalWarnFunction;
+    // Restore original p5.prototype._warn so we don't affect other tests.
+    p5.prototype._warn = originalWarnFunction;
   });
 
   describe("key aliases", function () {
     it("maps every alias to a numeric keycode", function () {
       for (var alias in KEY) {
-        expect(typeof keyCodeFromAlias_(alias)).to.equal('number');
+        expect(typeof _keyCodeFromAlias(alias)).to.equal('number');
       }
     });
 
@@ -37,25 +37,25 @@ describe('keyCodeFromAlias_', function() {
           }
         }).join('');
 
-        expect(keyCodeFromAlias_(upperCaseAlias))
-          .to.equal(keyCodeFromAlias_(lowerCaseAlias))
-          .to.equal(keyCodeFromAlias_(randomCaseAlias));
+        expect(_keyCodeFromAlias(upperCaseAlias))
+          .to.equal(_keyCodeFromAlias(lowerCaseAlias))
+          .to.equal(_keyCodeFromAlias(randomCaseAlias));
       }
     });
 
     it("does not warn when looking up a regular alias", function () {
       for (var alias in KEY) {
-        keyCodeFromAlias_(alias);
+        _keyCodeFromAlias(alias);
         expect(lastConsoleMessage).to.be.undefined;
       }
     });
 
     it("maps MINUS to 109", function () {
-      expect(keyCodeFromAlias_('MINUS')).to.equal(109);
+      expect(_keyCodeFromAlias('MINUS')).to.equal(109);
     });
 
     it("maps COMMA to 188", function () {
-      expect(keyCodeFromAlias_('COMMA')).to.equal(188);
+      expect(_keyCodeFromAlias('COMMA')).to.equal(188);
     });
   });
 
@@ -73,24 +73,24 @@ describe('keyCodeFromAlias_', function() {
     });
 
     it("aliases 'MINUT' to 'MINUS'", function() {
-      expect(keyCodeFromAlias_('MINUT'))
-        .to.equal(keyCodeFromAlias_('MINUS'));
+      expect(_keyCodeFromAlias('MINUT'))
+        .to.equal(_keyCodeFromAlias('MINUS'));
     });
 
     it("warns when using MINUT", function () {
-      keyCodeFromAlias_('MINUT');
+      _keyCodeFromAlias('MINUT');
       expect(lastConsoleMessage)
         .to.equal('Key literal "MINUT" is deprecated and may be removed in a ' +
                   'future version of p5.play. Please use "MINUS" instead.');
     });
 
     it("aliases 'COMA' to 'COMMA'", function() {
-      expect(keyCodeFromAlias_('COMA'))
-        .to.equal(keyCodeFromAlias_('COMMA'));
+      expect(_keyCodeFromAlias('COMA'))
+        .to.equal(_keyCodeFromAlias('COMMA'));
     });
 
     it("warns when using COMA", function () {
-      keyCodeFromAlias_('COMA');
+      _keyCodeFromAlias('COMA');
       expect(lastConsoleMessage)
         .to.equal('Key literal "COMA" is deprecated and may be removed in a ' +
                   'future version of p5.play. Please use "COMMA" instead.');


### PR DESCRIPTION
I realized that in the last few changes, I haven't been consistent with the new private methods I've introduced.  This change is a pure refactor that brings things in line.

**My understanding of the convention for private methods:**

* Private methods are named with a `_leadingUnderscore`
* Private methods are JSDoc annotated as [`@private`](http://usejsdoc.org/tags-private.html)

**Fixes made:**

* Rename `keyCodeFromAlias_` to `_keyCodeFromAlias`
* Rename `warn_` to `_warn`
* Correct JSDoc for `_warn`: Had wrong method name and was missing `@private` annotation
* Add JSDoc for `_ensureInGlobalMode`