### PR TITLE
Add support for jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "eqnull": true,
+  "asi": true,
+  "undef": true,
+  "globals": {
+    "p5": true,
+    "define": false,
+    "require": false
+  },
+  "maxerr": 1000000
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -4,6 +4,7 @@
   "undef": true,
   "globals": {
     "p5": true,
+    "window": true,
     "define": false,
     "require": false
   },

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4044,6 +4044,8 @@ p5.prototype.registerMethod('post', cameraPop);
  * @private
  */
 p5.prototype._warn = function (message) {
+  var console = window.console;
+
   if(console)
   {
     if('function' === typeof console.warn)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "jshint": "^2.9.1",
     "mocha-phantomjs": "^4.0.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "mocha-phantomjs": "^4.0.1"
   },
   "scripts": {
+    "lint": "jshint lib/",
     "test": "mocha-phantomjs test/index.html"
   },
   "repository": {


### PR DESCRIPTION
This adds support for [jshint](http://jshint.com/). It doesn't fix the vast majority of issues, which we can address in other PRs (in particular, the rest of the `**** is not defined` type warnings are fixed in #22).

Once we've fixed all the warnings, we should probably run `jshint` as part of the test suite, to ensure that warnings don't creep back into the codebase.