### PR TITLE
Smoke test examples on all browsers.

### DIFF
--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -15226,7 +15226,6 @@ p5.Renderer2D.prototype.shearY = function(angle) {
 };
 
 p5.Renderer2D.prototype.translate = function(x, y) {
-    console.log(x, y)
   this.drawingContext.translate(x, y);
   return this;
 };
@@ -16518,7 +16517,6 @@ p5.prototype.translate = function(x, y, z) {
     args[i] = arguments[i];
   }
 
-  console.log(x, y)
   if (this._renderer.isP3D) {
     this._validateParameters(
       'translate',

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3174,8 +3174,13 @@ function Animation() {
       var prefix1 = from.substring(0, from.length-(4+digits1));
       var prefix2 = to.substring(0, to.length-(4+digits2) );
 
-      var number1 = parseInt(from.substring(from.length-(4+digits1), from.length-4));
-      var number2 = parseInt(to.substring(to.length-(4+digits2), to.length-4));
+      // Our numbers likely have leading zeroes, which means that some
+      // browsers (e.g., PhantomJS) will interpret them as base 8 (octal)
+      // instead of decimal. To fix this, we'll explicity tell parseInt to
+      // use a base of 10 (decimal). For more details on this issue, see
+      // http://stackoverflow.com/a/8763427/2422398.
+      var number1 = parseInt(from.substring(from.length-(4+digits1), from.length-4), 10);
+      var number2 = parseInt(to.substring(to.length-(4+digits2), to.length-4), 10);
 
       //swap if inverted
       if(number2<number1)

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,10 @@
     <script src="../lib/p5.play.js"></script>
     <script src="unit/group.js"></script>
     <script src="unit/keycodes.js"></script>
+
+    <!-- Keep these at the end of the test list since they run slooooow. -->
+    <script src="unit/examples.js"></script>
+
     <script>
       // p5.play currently only works in global mode, not instance mode,
       // so we'll need to use that.

--- a/test/js/bind.js
+++ b/test/js/bind.js
@@ -1,28 +1,29 @@
 // `Function.prototype.bind` polyfill, included in the test environment because
 // PhantomJS does not implement it natively.
 // Source:
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Compatibility
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#Polyfill
 if (!Function.prototype.bind) {
-  Function.prototype.bind = function (oThis) {
-    if (typeof this !== "function") {
-      // closest thing possible to the ECMAScript 5 internal IsCallable
-      // function
-      throw new TypeError(
-        "Function.prototype.bind - what is trying to be bound is not callable"
-      );
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
     }
 
-    var aArgs = Array.prototype.slice.call(arguments, 1),
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
         fToBind = this,
-        fNOP = function () {},
-        fBound = function () {
-          return fToBind.apply(
-            this instanceof fNOP && oThis ? this : oThis,
-            aArgs.concat(Array.prototype.slice.call(arguments))
-          );
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
         };
 
-    fNOP.prototype = this.prototype;
+    if (this.prototype) {
+      // Function.prototype don't have a prototype property
+      fNOP.prototype = this.prototype; 
+    }
     fBound.prototype = new fNOP();
 
     return fBound;

--- a/test/unit/examples.js
+++ b/test/unit/examples.js
@@ -1,0 +1,85 @@
+describe('Example sketches', function() {
+  // These tests don't yet work in PhantomJS, so disable if we're in it.
+  if (/PhantomJS/.test(navigator.userAgent)) return;
+
+  var FILENAME_RE = /index\.html\?fileName=([A-Za-z0-9_.]+)/g;
+  var FRAMES_TO_DRAW = 3;
+
+  var iframe;
+  var examples = (function findExamples() {
+    var examples = [];
+    var req = new XMLHttpRequest();
+
+    req.open('GET', '../examples/index.html', false);
+    req.send(null);
+
+    req.responseText.replace(FILENAME_RE, function(_, fileName) {
+      examples.push(fileName);
+    });
+
+    return examples;
+  })();
+
+  // The following function's source code is converted to a string
+  // and evaluated in an iframe; it is NOT executed directly!
+  var iframeScript = function(parentWindowCbName, framesToDraw) {
+    var framesDrawn = 0;
+    var errorsLogged = 0;
+
+    window.onerror = function() {
+      errorsLogged++;
+    };
+
+    p5.prototype.registerMethod('post', function() {
+      if (++framesDrawn === framesToDraw) {
+        window.parent[parentWindowCbName](errorsLogged);
+      }
+    });
+  }.toString();
+
+  beforeEach(function() {
+    iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    iframe.style.visibility = 'hidden';
+    iframe.style.width = '640px';
+    iframe.style.height = '480px';
+  });
+
+  afterEach(function() {
+    iframe.parentNode.removeChild(iframe);
+  });
+
+  examples.forEach(function(fileName) {
+    var testName = fileName + ' runs for ' + FRAMES_TO_DRAW + ' frames';
+    it(testName, function(done) {
+      var windowCbName = 'example_' + fileName.slice(0, -3) + '_is_done';
+      var iframeScriptArgs = [
+        windowCbName,
+        FRAMES_TO_DRAW
+      ];
+      var iframeScriptCode = (
+        '(' +  iframeScript + ').apply(window, ' +
+        JSON.stringify(iframeScriptArgs) + ');'
+      );
+      window[windowCbName] = function exampleIsDone(errorsLogged) {
+        expect(errorsLogged).to.equal(0);
+        done();
+      };
+
+      iframe.contentDocument.open();
+      iframe.contentDocument.write([
+        '<!DOCTYPE html>',
+        '<meta charset="utf-8">',
+        '<base href="../examples/">',
+        '<title>Example: ' + fileName + '</title>',
+        '<h1>Example: ' + fileName + '</h1>',
+        '<div id="myP5"></div>',
+        '<script src="lib/p5.js"></script>',
+        '<script>' + iframeScriptCode + '</script>',
+        '<script src="../lib/p5.play.js"></script>',
+        '<script src="' + fileName + '"></script>',
+      ].join('\n'));
+      iframe.contentDocument.close();
+    });
+  });
+});

--- a/test/unit/examples.js
+++ b/test/unit/examples.js
@@ -2,11 +2,11 @@ describe('Example sketches', function() {
   // These tests don't yet work in PhantomJS, so disable if we're in it.
   if (/PhantomJS/.test(navigator.userAgent)) return;
 
-  var FILENAME_RE = /index\.html\?fileName=([A-Za-z0-9_.]+)/g;
   var FRAMES_TO_DRAW = 3;
 
   var iframe;
   var examples = (function findExamples() {
+    var FILENAME_RE = /index\.html\?fileName=([A-Za-z0-9_.]+)/g;
     var examples = [];
     var req = new XMLHttpRequest();
 

--- a/test/unit/examples.js
+++ b/test/unit/examples.js
@@ -1,7 +1,4 @@
 describe('Example sketches', function() {
-  // These tests don't yet work in PhantomJS, so disable if we're in it.
-  if (/PhantomJS/.test(navigator.userAgent)) return;
-
   var FRAMES_TO_DRAW = 3;
 
   var iframe;


### PR DESCRIPTION
This fixes #20~~, but doesn't currently work on PhantomJS, I think because PhantomJS is basically accessing the stuff over a `file:` protocol, which will make things barf. I guess we should start up a basic static web server for the PhantomJS tests to run against, but I'd like to file that as a separate bug~~.

The implementation works by running each example in an iframe and [registering](https://github.com/processing/p5.js/wiki/Libraries#use-registermethod-to-register-functions-with-p5-that-should-be-called-at-various-times) a `post` callback that waits for 3 frames to be drawn before completing. If any errors were thrown during this period, the test fails.

These tests run nicely on PhantomJS and Microsoft Edge (about 50-100ms per test), not-horribly on Chrome (about 100-200ms per test), but extremely slowly on Firefox (about 1.5-2 seconds per test). :disappointed: 

@islemaster want  to take a look at this?