### PR TITLE
Make 'npm start' serve examples.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "dependencies": {
   },
   "devDependencies": {
+    "http-server": "^0.9.0",
     "jshint": "^2.9.1",
     "mocha-phantomjs": "^4.0.1"
   },
   "scripts": {
     "lint": "jshint lib/",
+    "start": "http-server ./examples -o",
     "test": "mocha-phantomjs test/index.html"
   },
   "repository": {


### PR DESCRIPTION
I was trying to reverify #28 after the most recent rebase and realized you can't just open examples/index.html, so I thought this might be useful.

Uses the ['http-server' package](https://www.npmjs.com/package/http-server) to serve the examples directory on localhost:8080, and automatically opens them in a browser window.  This is a nice easy way to view the examples from a local copy of p5.play, since the AJAX requests they use to load the library are blocked by CORS rules when trying to open from a file:// URL.

This seems like an appropriate use of [`npm start`](https://docs.npmjs.com/cli/start) for this library, which typically starts a server.  You might consider an alternate approach, where `npm start` is used to begin a watch process for development, but since there's no 'build' system here that makes less sense to me.

Loading examples/index.html from filesystem:
![screenshot from 2016-02-24 14-25-22](https://cloud.githubusercontent.com/assets/1615761/13303211/c8a0cffc-db02-11e5-8919-48dd8225c4f7.png)

Running `npm start`:
![screenshot from 2016-02-24 14-25-56](https://cloud.githubusercontent.com/assets/1615761/13303210/c71726cc-db02-11e5-9e54-e95a1d658079.png)

Use from terminal:
![screenshot from 2016-02-24 14-31-36](https://cloud.githubusercontent.com/assets/1615761/13303330/8893f8de-db03-11e5-8017-3fba092d9eca.png)
