### PR TITLE
Improve and document 'npm start'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ http://localhost:8080/ in your browser.
 
 ### Unit Tests
 
-To run the unit tests in your browser, visit `test/index.html`.
+To run the unit tests in your browser, visit `http://localhost:8080/test/`.
 
 If you want to run them from the command-line, you can run
 `npm test`.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,35 @@
 
 p5.play is a p5.js library for the creation of games and playthings.
 
-You can find examples and more information at [p5play.molleindustria.org](http://p5play.molleindustria.org)
+You can find examples and more information at [p5play.molleindustria.org][].
 
 p5.play provides a Sprite class to manage visual objects in 2D space and features such as animation support, basic collision detection and resolution, sprite grouping, helpers for mouse and keyboard interactions, and a virtual camera. 
 
 p5.play extends p5.js, a javascript library (and a community) that aims to make coding accessible for artists, designers, educators, and beginners. If you are not familiar with p5.js, you should start at [p5js.org/tutorials](http://p5js.org/tutorials/).
 
-## Unit Tests
+## Development
+
+The following documentation is for *developing* p5.play itself. If you
+want to *use* p5.play, please see [p5play.molleindustria.org][].
+
+### Quick Start
+
+First install [node.js][]. Then run:
+
+```
+npm install
+npm start
+```
+
+Your web browser should open to a welcome page. If it doesn't, visit
+http://localhost:8080/ in your browser.
+
+### Unit Tests
 
 To run the unit tests in your browser, visit `test/index.html`.
 
 If you want to run them from the command-line, you can run
-`npm install` followed by `npm test`.
+`npm test`.
+
+  [p5play.molleindustria.org]: http://p5play.molleindustria.org
+  [node.js]: https://nodejs.org/en/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  font-family: 'Open Sans', sans-serif;
+  font-size:20px;
+  color: #444;
+}
+
+a:link, a:visited {
+  color: #2D7BB6;
+  text-decoration: none;
+}
+
+a:active, a:hover, #reference a:hover {
+  color:#ED225D;
+  text-decoration: none;
+  padding-bottom: 0.11em;
+  border-bottom: 0.11em dashed;
+  border-bottom-color: #ED225D;
+  transition: border-bottom 30ms linear;
+}
+
+#navMenu, #navMenu a {
+  font-size:23px; 
+  color: #ED225D;
+}
+</style>
+<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,600" rel="stylesheet">
+<title>Welcome to p5.play development!</title>
+<div id="navMenu">
+  <a href="examples/">Examples</a>
+  *
+  <a href="test/">Test Suite</a>
+  *
+  <a href="https://github.com/molleindustria/p5.play/">GitHub</a>
+</div>  
+<p>Welcome to <strong>p5.play</strong> development!</p>
+<p>See the <a href="https://github.com/molleindustria/p5.play/#readme">README</a> for help on getting started.</p>
+<p>
+  Initiated by <strong>Paolo Pedercini</strong> | 
+  <a href="http://molleindustria.org/">molleindustria.org</a> |
+  <a href="https://twitter.com/molleindustria">@molleindustria</a>
+</p>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "lint": "jshint lib/",
-    "start": "http-server ./examples -o",
+    "start": "http-server -o",
     "test": "mocha-phantomjs test/index.html"
   },
   "repository": {


### PR DESCRIPTION
This builds on #39 by serving from the root of the repository, which allows developers to easily access the test suite as well as the examples (and hopefully in the near future, the dynamically generated reference documentation too!).

It also adds a friendly welcome page to the root of the repository that offers easy access to the examples and test suite:

![2016-02-27_7-20-36](https://cloud.githubusercontent.com/assets/124687/13372829/9d585848-dd22-11e5-9a7e-2eda4cb401c1.png)

It also documents `npm start` in the README.

Thoughts @islemaster?
