### PR TITLE
Add tests for input methods.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@
     <script src="../lib/p5.play.js"></script>
     <script src="unit/group.js"></script>
     <script src="unit/keycodes.js"></script>
+    <script src="unit/input.js"></script>
     <script src="unit/spritesheet.js"></script>
     <script src="unit/sketch-properties.js"></script>
 

--- a/test/unit/input.js
+++ b/test/unit/input.js
@@ -1,0 +1,118 @@
+describe('Input', function() {
+  var myp5;
+  var LEFT_ARROW, LEFT;
+
+  beforeEach(function() {
+    myp5 = new p5(function() {});
+    LEFT_ARROW = myp5.LEFT_ARROW;
+    LEFT = myp5.LEFT;
+  });
+
+  afterEach(function() {
+    myp5.remove();
+  });
+
+  function mouseup(which) {
+    myp5._setProperty('mouseButton', which);
+    myp5._setProperty('mouseIsPressed', false);
+  }
+
+  function mousedown(which) {
+    myp5._setProperty('mouseButton', which);
+    myp5._setProperty('mouseIsPressed', true);
+  }
+
+  function keydown(which) {
+    myp5._onkeydown({which: which});
+  }
+
+  function keyup(which) {
+    myp5._onkeyup({which: which});
+  }
+
+  function nextFrame() {
+    myp5.readPresses();
+  }
+
+  it('reports mouseDown() properly', function() {
+    mouseup(LEFT);
+    nextFrame();
+
+    expect(myp5.mouseDown(LEFT)).to.be.false;
+
+    mousedown(LEFT);
+    nextFrame();
+
+    // TODO: Is this actually the expected behavior?
+    expect(myp5.mouseDown(LEFT)).to.be.false;
+
+    nextFrame();
+
+    expect(myp5.mouseDown(LEFT)).to.be.true;
+  });
+
+  it('reports mouseWentDown() properly', function() {
+    mouseup(LEFT);
+    nextFrame();
+
+    expect(myp5.mouseWentDown(LEFT)).to.be.false;
+
+    mousedown(LEFT);
+    nextFrame();
+
+    expect(myp5.mouseWentDown(LEFT)).to.be.true;
+  });
+
+  it('reports mouseWentUp() properly', function() {
+    mousedown(LEFT);
+    nextFrame();
+
+    expect(myp5.mouseWentUp(LEFT)).to.be.false;
+
+    mouseup(LEFT);
+    nextFrame();
+
+    expect(myp5.mouseWentUp(LEFT)).to.be.true;
+  });
+
+  it('reports keyDown() properly', function() {
+    keyup(LEFT_ARROW);
+    nextFrame();
+
+    expect(myp5.keyDown(LEFT_ARROW)).to.be.false;
+
+    keydown(LEFT_ARROW);
+    nextFrame();
+
+    // TODO: Is this actually the expected behavior?
+    expect(myp5.keyDown(LEFT_ARROW)).to.be.false;
+
+    nextFrame();
+
+    expect(myp5.keyDown(LEFT_ARROW)).to.be.true;
+  });
+
+  it('reports keyWentDown() properly', function() {
+    keyup(LEFT_ARROW);
+    nextFrame();
+
+    expect(myp5.keyWentDown(LEFT_ARROW)).to.be.false;
+
+    keydown(LEFT_ARROW);
+    nextFrame();
+
+    expect(myp5.keyWentDown(LEFT_ARROW)).to.be.true;
+  });
+
+  it('reports keyWentUp() properly', function() {
+    keydown(LEFT_ARROW);
+    nextFrame();
+
+    expect(myp5.keyWentUp(LEFT_ARROW)).to.be.false;
+
+    keyup(LEFT_ARROW);
+    nextFrame();
+
+    expect(myp5.keyWentUp(LEFT_ARROW)).to.be.true;
+  });
+});

--- a/test/unit/input.js
+++ b/test/unit/input.js
@@ -44,6 +44,7 @@ describe('Input', function() {
     nextFrame();
 
     // TODO: Is this actually the expected behavior?
+    // See https://github.com/molleindustria/p5.play/issues/43 for details.
     expect(myp5.mouseUp(LEFT)).to.be.false;
 
     nextFrame();
@@ -61,6 +62,7 @@ describe('Input', function() {
     nextFrame();
 
     // TODO: Is this actually the expected behavior?
+    // See https://github.com/molleindustria/p5.play/issues/43 for details.
     expect(myp5.mouseDown(LEFT)).to.be.false;
 
     nextFrame();
@@ -107,6 +109,7 @@ describe('Input', function() {
     nextFrame();
 
     // TODO: Is this actually the expected behavior?
+    // See https://github.com/molleindustria/p5.play/issues/43 for details.
     expect(myp5.keyDown(LEFT_ARROW)).to.be.false;
 
     nextFrame();

--- a/test/unit/input.js
+++ b/test/unit/input.js
@@ -34,6 +34,23 @@ describe('Input', function() {
     myp5.readPresses();
   }
 
+  it('reports mouseUp() properly', function() {
+    mousedown(LEFT);
+    nextFrame();
+
+    expect(myp5.mouseUp(LEFT)).to.be.false;
+
+    mouseup(LEFT);
+    nextFrame();
+
+    // TODO: Is this actually the expected behavior?
+    expect(myp5.mouseUp(LEFT)).to.be.false;
+
+    nextFrame();
+
+    expect(myp5.mouseUp(LEFT)).to.be.true;
+  });
+
   it('reports mouseDown() properly', function() {
     mouseup(LEFT);
     nextFrame();
@@ -61,6 +78,11 @@ describe('Input', function() {
     nextFrame();
 
     expect(myp5.mouseWentDown(LEFT)).to.be.true;
+
+    mouseup(LEFT);
+    nextFrame();
+
+    expect(myp5.mouseWentDown(LEFT)).to.be.false;
   });
 
   it('reports mouseWentUp() properly', function() {
@@ -102,6 +124,11 @@ describe('Input', function() {
     nextFrame();
 
     expect(myp5.keyWentDown(LEFT_ARROW)).to.be.true;
+
+    keyup(LEFT_ARROW);
+    nextFrame();
+
+    expect(myp5.keyWentDown(LEFT_ARROW)).to.be.false;
   });
 
   it('reports keyWentUp() properly', function() {

--- a/test/unit/input.js
+++ b/test/unit/input.js
@@ -81,7 +81,6 @@ describe('Input', function() {
 
     expect(myp5.mouseWentDown(LEFT)).to.be.true;
 
-    mouseup(LEFT);
     nextFrame();
 
     expect(myp5.mouseWentDown(LEFT)).to.be.false;
@@ -128,7 +127,6 @@ describe('Input', function() {
 
     expect(myp5.keyWentDown(LEFT_ARROW)).to.be.true;
 
-    keyup(LEFT_ARROW);
     nextFrame();
 
     expect(myp5.keyWentDown(LEFT_ARROW)).to.be.false;


### PR DESCRIPTION
This adds tests for the input methods in p5.play. I actually used it to ensure that #28 didn't cause regressions. :grin: 

However, I think I *might* have also uncovered a bug. The documentation for `keyDown` states:

```
Like p5 keyIsDown but accepts strings and codes
```

However, the implementation is checking to see if the internal key state is specifically equal to `KEY_IS_DOWN`. The problem is that the internal keystate might actually be `KEY_WENT_DOWN`, in which case the method will retrun `false` but `keyIsDown()` will be `true`!

It's understandable that no one has noticed this, because it just means that the result of `keyDown` will be inconsistent with `keyIsDown` for only the frame in which the key went from up to down.

A parallel problem exists with `mouseDown`/`mouseIsDown`.

@islemaster is this something you think we should change? And does the test suite look  OK overall?