### PR TITLE
Tests for collision methods and fix bugs in return values

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2233,7 +2233,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
               displacement = this.collider.collide(other.collider);
 
 
-            if(displacement.x != 0 || displacement.y != 0 )
+            if(displacement.x !== 0 || displacement.y !== 0 )
             {
               other.position.sub(displacement);
 
@@ -2637,12 +2637,14 @@ function Group() {
    * type.  Return true if any collision occurred.
    * Internal use
    *
+   * @private
+   * @method _groupCollide
    * @param {!string} type one of 'overlap', 'collide', 'displace', 'bounce'
    * @param {Object} target Group or Sprite
    * @param {Function} [callback] on collision.
    * @returns {boolean} True if any collision/overlap occurred
    */
-  function groupCollide(type, target, callback) {
+  function _groupCollide(type, target, callback) {
     var didCollide = false;
     for(var i = 0; i<this.size(); i++)
       didCollide = this.get(i).AABBops(type, target, callback) || didCollide;
@@ -2675,7 +2677,7 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.overlap = groupCollide.bind(array, 'overlap');
+  array.overlap = _groupCollide.bind(array, 'overlap');
 
 
   /**
@@ -2707,7 +2709,7 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.collide = groupCollide.bind(array, 'collide');
+  array.collide = _groupCollide.bind(array, 'collide');
 
   /**
   * Checks if the the group is overlapping another group.
@@ -2738,7 +2740,7 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.displace = groupCollide.bind(array, 'displace');
+  array.displace = _groupCollide.bind(array, 'displace');
 
   /**
   * Checks if the the group is overlapping another group.
@@ -2769,7 +2771,7 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.bounce = groupCollide.bind(array, 'bounce');
+  array.bounce = _groupCollide.bind(array, 'bounce');
 
   return array;
 }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2697,8 +2697,10 @@ function Group() {
   * @returns {Boolean} True if overlapping
   */
   array.collide = function(target, callback) {
+    var didCollide = false;
     for(var i = 0; i<this.size(); i++)
-      this.get(i).AABBops("collide", target, callback);
+      didCollide = this.get(i).AABBops("collide", target, callback) || didCollide;
+    return didCollide;
   }
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2632,6 +2632,22 @@ function Group() {
     return obj === other;
   }
 
+  /**
+   * Collide each member of group against the target using the given collision
+   * type.  Return true if any collision occurred.
+   * Internal use
+   *
+   * @param {!string} type one of 'overlap', 'collide', 'displace', 'bounce'
+   * @param {Object} target Group or Sprite
+   * @param {Function} [callback] on collision.
+   * @returns {boolean} True if any collision/overlap occurred
+   */
+  function groupCollide(type, target, callback) {
+    var didCollide = false;
+    for(var i = 0; i<this.size(); i++)
+      didCollide = this.get(i).AABBops(type, target, callback) || didCollide;
+    return didCollide;
+  }
 
   /**
   * Checks if the the group is overlapping another group.
@@ -2659,12 +2675,7 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.overlap = function(target, callback) {
-    var didOverlap = false;
-    for(var i = 0; i<this.size(); i++)
-      didOverlap = this.get(i).AABBops("overlap", target, callback) || didOverlap;
-    return didOverlap;
-  }
+  array.overlap = groupCollide.bind(array, 'overlap');
 
 
   /**
@@ -2696,12 +2707,7 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.collide = function(target, callback) {
-    var didCollide = false;
-    for(var i = 0; i<this.size(); i++)
-      didCollide = this.get(i).AABBops("collide", target, callback) || didCollide;
-    return didCollide;
-  }
+  array.collide = groupCollide.bind(array, 'collide');
 
   /**
   * Checks if the the group is overlapping another group.
@@ -2732,12 +2738,7 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.displace = function(target, callback) {
-    var didDisplace = false;
-    for(var i = 0; i<this.size(); i++)
-      didDisplace = this.get(i).AABBops("displace", target, callback) || didDisplace;
-    return didDisplace;
-  }
+  array.displace = groupCollide.bind(array, 'displace');
 
   /**
   * Checks if the the group is overlapping another group.
@@ -2768,12 +2769,8 @@ function Group() {
   * @param {Function} [callback] The function to be called if overlap is positive
   * @returns {Boolean} True if overlapping
   */
-  array.bounce = function(target, callback) {
-    var didBounce = false;
-    for(var i = 0; i<this.size(); i++)
-      didBounce = this.get(i).AABBops("bounce", target, callback) || didBounce;
-    return didBounce;
-  }
+  array.bounce = groupCollide.bind(array, 'bounce');
+
   return array;
 }
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2735,8 +2735,10 @@ function Group() {
   * @returns {Boolean} True if overlapping
   */
   array.displace = function(target, callback) {
+    var didDisplace = false;
     for(var i = 0; i<this.size(); i++)
-      this.get(i).AABBops("displace", target, callback);
+      didDisplace = this.get(i).AABBops("displace", target, callback) || didDisplace;
+    return didDisplace;
   }
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2236,7 +2236,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
 
             if(displacement.x == 0 &&  displacement.y == 0 )
-              result = false;
+              result = result || false;
             else
             {
               other.position.sub(displacement);

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2769,8 +2769,10 @@ function Group() {
   * @returns {Boolean} True if overlapping
   */
   array.bounce = function(target, callback) {
+    var didBounce = false;
     for(var i = 0; i<this.size(); i++)
-      this.get(i).AABBops("bounce", target, callback);
+      didBounce = this.get(i).AABBops("bounce", target, callback) || didBounce;
+    return didBounce;
   }
   return array;
 }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2664,8 +2664,10 @@ function Group() {
   * @returns {Boolean} True if overlapping
   */
   array.overlap = function(target, callback) {
+    var didOverlap = false;
     for(var i = 0; i<this.size(); i++)
-      this.get(i).AABBops("overlap", target, callback);
+      didOverlap = this.get(i).AABBops("overlap", target, callback) || didOverlap;
+    return didOverlap;
   }
 
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2141,9 +2141,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
             }
 
-            if(displacement.x == 0 &&  displacement.y == 0 )
-              result = false;
-            else
+            if(displacement.x !== 0 || displacement.y !== 0)
             {
 
               if(!this.immovable)
@@ -2235,9 +2233,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
               displacement = this.collider.collide(other.collider);
 
 
-            if(displacement.x == 0 &&  displacement.y == 0 )
-              result = result || false;
-            else
+            if(displacement.x != 0 || displacement.y != 0 )
             {
               other.position.sub(displacement);
 

--- a/test/index.html
+++ b/test/index.html
@@ -23,7 +23,7 @@
     <script src="unit/sketch-properties.js"></script>
 
     <!-- Keep these at the end of the test list since they run slooooow. -->
-    <!--<script src="unit/examples.js"></script>-->
+    <script src="unit/examples.js"></script>
     <script>
       window.addEventListener("load", function() {
         mocha.run();

--- a/test/index.html
+++ b/test/index.html
@@ -16,13 +16,14 @@
     </script>
     <script src="../examples/lib/p5.js"></script>
     <script src="../lib/p5.play.js"></script>
+    <script src="unit/collisions.js"></script>
     <script src="unit/group.js"></script>
     <script src="unit/keycodes.js"></script>
     <script src="unit/spritesheet.js"></script>
     <script src="unit/sketch-properties.js"></script>
 
     <!-- Keep these at the end of the test list since they run slooooow. -->
-    <script src="unit/examples.js"></script>
+    <!--<script src="unit/examples.js"></script>-->
     <script>
       window.addEventListener("load", function() {
         mocha.run();

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -534,5 +534,62 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('displace(sprite)', function () {
+      it('false if no sprites overlap', function () {
+        expect(groupAB.displace(spriteC)).to.be.false;
+      });
+
+      it('false if no sprite in group overlaps target sprite', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.displace(spriteC)).to.be.false;
+      });
+
+      it('true if all sprites in group overlap target sprite', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.displace(spriteC)).to.be.true;
+      });
+
+      describe('true if any sprites in group overlap target sprite', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expect(groupAB.displace(spriteC)).to.be.true;
+        });
+
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expect(groupAB.displace(spriteC)).to.be.true;
+        });
+      });
+
+      it('does not call callback when not overlapping sprite', function () {
+        groupAB.displace(spriteC, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback for each overlap', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.displace(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.displace(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C', function () {
+          moveAToB(spriteA, spriteC);
+          moveAToB(spriteB, spriteC);
+          groupAB.displace(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+          // Note: First collision (A-C) displaces C away from A and B,
+          //       so the second collision (B-C) never happens.
+        });
+      });
+    });
   });
 });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -591,5 +591,153 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('displace(group)', function () {
+      it('false if no sprites overlap', function () {
+        expect(groupAB.displace(groupCD)).to.be.false;
+      });
+
+      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+        moveAToB(spriteA, spriteB);
+        moveAToB(spriteC, spriteD);
+        expect(groupAB.displace(groupCD)).to.be.false;
+      });
+
+      it('true if all sprites in group AB overlap all sprites in group CD', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expect(groupAB.displace(groupCD)).to.be.true;
+      });
+
+      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expect(groupAB.displace(groupCD)).to.be.true;
+        });
+
+        it('A overlaps D', function () {
+          moveAToB(spriteA, spriteD);
+          expect(groupAB.displace(groupCD)).to.be.true;
+        });
+
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expect(groupAB.displace(groupCD)).to.be.true;
+        });
+
+        it('B overlaps D', function () {
+          moveAToB(spriteB, spriteD);
+          expect(groupAB.displace(groupCD)).to.be.true;
+        });
+      });
+
+      it('group does not overlap self if no sprites within group overlap', function () {
+        expect(groupAB.displace(groupAB)).to.be.false;
+      });
+
+      it('group overlaps self if two different sprites within group overlap', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.displace(groupAB)).to.be.true;
+      });
+
+      it('does not call callback when not overlapping any sprites', function () {
+        groupAB.displace(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback for each pair', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
+
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
+
+        it('B-D', function () {
+          moveAToB(spriteB, spriteD);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+        });
+
+        it('A-B-C', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+          // Note: First collision (A-C) displaces C away from A and B,
+          //       so the second collision (B-C) never happens.
+        });
+
+        it('A-B-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+          // Note: First collision (A-D) displaces D away from A and B,
+          //       so the second collision (B-D) never happens.
+        });
+
+        it('A-C-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteA.name, spriteD.name]]);
+        });
+
+        it('B-C-D', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteB);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteB.name, spriteC.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-C, B-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteB);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-D, B-C', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteA);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteA.name, spriteD.name]]);
+          // Note: First collision (A-C) and second collision (A-D)
+          // displace C and D away from A and B,
+          // so the third and fourth collisions (B-C and B-D) never happen.
+        });
+      });
+    });
   });
 });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -930,5 +930,151 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('collide(group)', function () {
+      it('false if no sprites overlap', function () {
+        expect(groupAB.collide(groupCD)).to.be.false;
+      });
+
+      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+        moveAToB(spriteA, spriteB);
+        moveAToB(spriteC, spriteD);
+        expect(groupAB.collide(groupCD)).to.be.false;
+      });
+
+      it('true if all sprites in group AB overlap all sprites in group CD', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expect(groupAB.collide(groupCD)).to.be.true;
+      });
+
+      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expect(groupAB.collide(groupCD)).to.be.true;
+        });
+
+        it('A overlaps D', function () {
+          moveAToB(spriteA, spriteD);
+          expect(groupAB.collide(groupCD)).to.be.true;
+        });
+
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expect(groupAB.collide(groupCD)).to.be.true;
+        });
+
+        it('B overlaps D', function () {
+          moveAToB(spriteB, spriteD);
+          expect(groupAB.collide(groupCD)).to.be.true;
+        });
+      });
+
+      it('group does not overlap self if no sprites within group overlap', function () {
+        expect(groupAB.collide(groupAB)).to.be.false;
+      });
+
+      it('group overlaps self if two different sprites within group overlap', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.collide(groupAB)).to.be.true;
+      });
+
+      it('does not call callback when not overlapping any sprites', function () {
+        groupAB.collide(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback for each pair', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
+
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
+
+        it('B-D', function () {
+          moveAToB(spriteB, spriteD);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+        });
+
+        it('A-B-C', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-C-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name]]);
+          // Note: due to displacement, only the first collision occurs.
+        });
+
+        it('B-C-D', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteB);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteB.name, spriteC.name]]);
+          // Note: due to displacement, only the first collision occurs.
+        });
+
+        it('A-C, B-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteB);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-D, B-C', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteA);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+          // Note: Due to displacement, only two collisions occur.
+        });
+      });
+    });
   });
 });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -1,0 +1,88 @@
+describe('collisions', function() {
+  var pInst;
+
+  beforeEach(function () {
+    pInst = new p5(function() {});
+  });
+
+  afterEach(function () {
+    pInst.remove();
+  });
+
+  describe('sprite-sprite', function () {
+    const SIZE = 10;
+    var spriteA, spriteB;
+    var countingCallback;
+    var argTrackingCallback;
+
+    beforeEach(function () {
+      spriteA = pInst.createSprite(0, 0, SIZE, SIZE);
+      spriteB = pInst.createSprite(0, 0, SIZE, SIZE);
+
+      // Count callback calls
+      countingCallback = function () {
+        countingCallback.callCount++;
+      };
+      countingCallback.callCount = 0;
+
+      // Remember last arguments to callback
+      argTrackingCallback = function () {
+        argTrackingCallback.lastArgs = arguments;
+      };
+    });
+
+    describe('overlap', function () {
+      it('returns true if sprites overlap', function () {
+        expect(spriteA.overlap(spriteB)).to.be.true;
+        expect(spriteB.overlap(spriteA)).to.be.true;
+      });
+
+      it('returns false if sprites do not overlap', function () {
+        spriteB.position.x += 2 * SIZE;
+        expect(spriteA.overlap(spriteB)).to.be.false;
+        expect(spriteB.overlap(spriteA)).to.be.false;
+      });
+
+      it('sprites overlap when edges just touch', function () {
+        spriteB.position.x += SIZE;
+        expect(spriteA.overlap(spriteB)).to.be.true;
+        expect(spriteB.overlap(spriteA)).to.be.true;
+
+        spriteB.position.x += 0.0001;
+        expect(spriteA.overlap(spriteB)).to.be.false;
+        expect(spriteB.overlap(spriteA)).to.be.false;
+      });
+
+      it('calls callback once if sprites overlap', function () {
+        expect(countingCallback.callCount).to.equal(0);
+        spriteA.overlap(spriteB, countingCallback);
+        expect(countingCallback.callCount).to.equal(1);
+        spriteB.overlap(spriteA, countingCallback);
+        expect(countingCallback.callCount).to.equal(2);
+      });
+
+      it('does not call callback if sprites do not overlap', function () {
+        spriteB.position.x += 2 * SIZE;
+        expect(countingCallback.callCount).to.equal(0);
+        spriteA.overlap(spriteB, countingCallback);
+        expect(countingCallback.callCount).to.equal(0);
+        spriteB.overlap(spriteA, countingCallback);
+        expect(countingCallback.callCount).to.equal(0);
+      });
+
+      it('passes collider and collidee to callback', function () {
+        spriteA.overlap(spriteB, argTrackingCallback);
+        expect(argTrackingCallback.lastArgs).to.be.arguments;
+        expect(argTrackingCallback.lastArgs.length).to.be.at.least(2);
+        expect(argTrackingCallback.lastArgs[0]).to.equal(spriteA);
+        expect(argTrackingCallback.lastArgs[1]).to.equal(spriteB);
+
+        spriteB.overlap(spriteA, argTrackingCallback);
+        expect(argTrackingCallback.lastArgs).to.be.arguments;
+        expect(argTrackingCallback.lastArgs.length).to.be.at.least(2);
+        expect(argTrackingCallback.lastArgs[0]).to.equal(spriteB);
+        expect(argTrackingCallback.lastArgs[1]).to.equal(spriteA);
+      });
+    });
+  });
+});

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -1267,5 +1267,151 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('bounce(group)', function () {
+      it('false if no sprites overlap', function () {
+        expect(groupAB.bounce(groupCD)).to.be.false;
+      });
+
+      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+        moveAToB(spriteA, spriteB);
+        moveAToB(spriteC, spriteD);
+        expect(groupAB.bounce(groupCD)).to.be.false;
+      });
+
+      it('true if all sprites in group AB overlap all sprites in group CD', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expect(groupAB.bounce(groupCD)).to.be.true;
+      });
+
+      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expect(groupAB.bounce(groupCD)).to.be.true;
+        });
+
+        it('A overlaps D', function () {
+          moveAToB(spriteA, spriteD);
+          expect(groupAB.bounce(groupCD)).to.be.true;
+        });
+
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expect(groupAB.bounce(groupCD)).to.be.true;
+        });
+
+        it('B overlaps D', function () {
+          moveAToB(spriteB, spriteD);
+          expect(groupAB.bounce(groupCD)).to.be.true;
+        });
+      });
+
+      it('group does not overlap self if no sprites within group overlap', function () {
+        expect(groupAB.bounce(groupAB)).to.be.false;
+      });
+
+      it('group overlaps self if two different sprites within group overlap', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.bounce(groupAB)).to.be.true;
+      });
+
+      it('does not call callback when not overlapping any sprites', function () {
+        groupAB.bounce(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback for each pair', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
+
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
+
+        it('B-D', function () {
+          moveAToB(spriteB, spriteD);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+        });
+
+        it('A-B-C', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-C-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name]]);
+          // Note: due to displacement, only the first collision occurs.
+        });
+
+        it('B-C-D', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteB);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteB.name, spriteC.name]]);
+          // Note: due to displacement, only the first collision occurs.
+        });
+
+        it('A-C, B-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteB);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-D, B-C', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteA);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+          // Note: Due to displacement, only two collisions occur.
+        });
+      });
+    });
   });
 });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -66,1351 +66,1347 @@ describe('collisions', function() {
     pInst.remove();
   });
 
-  describe('sprite', function () {
-    describe('overlap(sprite)', function () {
-      it('false if sprites do not overlap', function () {
-        expect(spriteA.overlap(spriteB)).to.be.false;
-        expect(spriteB.overlap(spriteA)).to.be.false;
-      });
+  describe('sprite.overlap(sprite)', function () {
+    it('false if sprites do not overlap', function () {
+      expect(spriteA.overlap(spriteB)).to.be.false;
+      expect(spriteB.overlap(spriteA)).to.be.false;
+    });
 
-      it('true if sprites overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.overlap(spriteB)).to.be.true;
-        expect(spriteB.overlap(spriteA)).to.be.true;
-      });
+    it('true if sprites overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.overlap(spriteB)).to.be.true;
+      expect(spriteB.overlap(spriteA)).to.be.true;
+    });
 
-      it('calls callback once if sprites overlap', function () {
+    it('calls callback once if sprites overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(callCount).to.equal(0);
+      spriteA.overlap(spriteB, testCallback);
+      expect(callCount).to.equal(1);
+      spriteB.overlap(spriteA, testCallback);
+      expect(callCount).to.equal(2);
+    });
+
+    it('does not call callback if sprites do not overlap', function () {
+      expect(callCount).to.equal(0);
+      spriteA.overlap(spriteB, testCallback);
+      expect(callCount).to.equal(0);
+      spriteB.overlap(spriteA, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-B', function () {
         moveAToB(spriteA, spriteB);
-        expect(callCount).to.equal(0);
         spriteA.overlap(spriteB, testCallback);
-        expect(callCount).to.equal(1);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+      });
+
+      it('B-A', function () {
+        moveAToB(spriteA, spriteB);
         spriteB.overlap(spriteA, testCallback);
-        expect(callCount).to.equal(2);
-      });
-
-      it('does not call callback if sprites do not overlap', function () {
-        expect(callCount).to.equal(0);
-        spriteA.overlap(spriteB, testCallback);
-        expect(callCount).to.equal(0);
-        spriteB.overlap(spriteA, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-B', function () {
-          moveAToB(spriteA, spriteB);
-          spriteA.overlap(spriteB, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
-        });
-
-        it('B-A', function () {
-          moveAToB(spriteA, spriteB);
-          spriteB.overlap(spriteA, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
-        });
-      });
-    });
-
-    describe('overlap(group)', function () {
-      it('false if sprite does not overlap any sprites in group', function () {
-        expect(spriteA.overlap(groupCD)).to.be.false;
-      });
-
-      it('does not check against sprites not in target group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.overlap(groupCD)).to.be.false;
-      });
-
-      it('does not care if sprites in target group overlap each other', function () {
-        moveAToB(spriteC, spriteD);
-        expect(spriteA.overlap(groupCD)).to.be.false;
-      });
-
-      it('true if sprite overlaps first sprite in group', function () {
-        moveAToB(spriteA, spriteC);
-        expect(spriteA.overlap(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps last sprite in group', function () {
-        moveAToB(spriteA, spriteD);
-        expect(spriteA.overlap(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps every sprite in group', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        expect(spriteA.overlap(groupCD)).to.be.true;
-      });
-
-      it('does not overlap self when checking own group', function () {
-        expect(spriteA.overlap(groupAB)).to.be.false;
-      });
-
-      it('can overlap with other sprites in own group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.overlap(groupAB)).to.be.true;
-      });
-
-      it('does not call callback when not overlapping any sprites', function () {
-        spriteA.overlap(groupCD, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      it('calls callback once when overlapping one sprite', function () {
-        moveAToB(spriteC, spriteA);
-        spriteA.overlap(groupCD, testCallback);
-        expect(callCount).to.equal(1);
-      });
-
-      it('calls callback twice when overlapping two sprites', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        spriteA.overlap(groupCD, testCallback);
-        expect(callCount).to.equal(2);
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          spriteA.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          spriteA.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
-
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          spriteA.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteA.name, spriteD.name]]);
-        });
-      });
-    });
-
-    describe('displace(sprite)', function () {
-      it('false if sprites do not overlap', function () {
-        expect(spriteA.displace(spriteB)).to.be.false;
-        expect(spriteB.displace(spriteA)).to.be.false;
-      });
-
-      it('true if sprites overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.displace(spriteB)).to.be.true;
-
-        moveAToB(spriteA, spriteB);
-        expect(spriteB.displace(spriteA)).to.be.true;
-      });
-
-      it('calls callback once if sprites overlap', function () {
-        expect(callCount).to.equal(0);
-
-        moveAToB(spriteA, spriteB);
-        spriteA.displace(spriteB, testCallback);
-        expect(callCount).to.equal(1);
-
-        moveAToB(spriteA, spriteB);
-        spriteB.displace(spriteA, testCallback);
-        expect(callCount).to.equal(2);
-      });
-
-      it('does not call callback if sprites do not overlap', function () {
-        expect(callCount).to.equal(0);
-        spriteA.displace(spriteB, testCallback);
-        expect(callCount).to.equal(0);
-        spriteB.displace(spriteA, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-B', function () {
-          moveAToB(spriteA, spriteB);
-          spriteA.displace(spriteB, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
-        });
-
-        it('B-A', function () {
-          moveAToB(spriteA, spriteB);
-          spriteB.displace(spriteA, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
-        });
-      });
-    });
-
-    describe('displace(group)', function () {
-      it('false if sprite does not overlap any sprites in group', function () {
-        expect(spriteA.displace(groupCD)).to.be.false;
-      });
-
-      it('does not check against sprites not in target group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.displace(groupCD)).to.be.false;
-      });
-
-      it('does not care if sprites in target group overlap each other', function () {
-        moveAToB(spriteC, spriteD);
-        expect(spriteA.displace(groupCD)).to.be.false;
-      });
-
-      it('true if sprite overlaps first sprite in group', function () {
-        moveAToB(spriteA, spriteC);
-        expect(spriteA.displace(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps last sprite in group', function () {
-        moveAToB(spriteA, spriteD);
-        expect(spriteA.displace(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps every sprite in group', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        expect(spriteA.displace(groupCD)).to.be.true;
-      });
-
-      it('does not overlap self when checking own group', function () {
-        expect(spriteA.displace(groupAB)).to.be.false;
-      });
-
-      it('can overlap with other sprites in own group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.displace(groupAB)).to.be.true;
-      });
-
-      it('does not call callback when not overlapping any sprites', function () {
-        spriteA.displace(groupCD, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      it('calls callback once when overlapping one sprite', function () {
-        moveAToB(spriteC, spriteA);
-        spriteA.displace(groupCD, testCallback);
-        expect(callCount).to.equal(1);
-      });
-
-      it('calls callback twice when overlapping two sprites', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        spriteA.displace(groupCD, testCallback);
-        expect(callCount).to.equal(2);
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          spriteA.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          spriteA.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
-
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          spriteA.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteA.name, spriteD.name]]);
-        });
-      });
-    });
-
-    describe('collide(sprite)', function () {
-      it('false if sprites do not overlap', function () {
-        expect(spriteA.collide(spriteB)).to.be.false;
-        expect(spriteB.collide(spriteA)).to.be.false;
-      });
-
-      it('true if sprites overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.collide(spriteB)).to.be.true;
-
-        moveAToB(spriteA, spriteB);
-        expect(spriteB.collide(spriteA)).to.be.true;
-      });
-
-      it('calls callback once if sprites overlap', function () {
-        expect(callCount).to.equal(0);
-
-        moveAToB(spriteA, spriteB);
-        spriteA.collide(spriteB, testCallback);
-        expect(callCount).to.equal(1);
-
-        moveAToB(spriteA, spriteB);
-        spriteB.collide(spriteA, testCallback);
-        expect(callCount).to.equal(2);
-      });
-
-      it('does not call callback if sprites do not overlap', function () {
-        expect(callCount).to.equal(0);
-        spriteA.collide(spriteB, testCallback);
-        expect(callCount).to.equal(0);
-        spriteB.collide(spriteA, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-B', function () {
-          moveAToB(spriteA, spriteB);
-          spriteA.collide(spriteB, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
-        });
-
-        it('B-A', function () {
-          moveAToB(spriteA, spriteB);
-          spriteB.collide(spriteA, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
-        });
-      });
-    });
-
-    describe('collide(group)', function () {
-      it('false if sprite does not overlap any sprites in group', function () {
-        expect(spriteA.collide(groupCD)).to.be.false;
-      });
-
-      it('does not check against sprites not in target group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.collide(groupCD)).to.be.false;
-      });
-
-      it('does not care if sprites in target group overlap each other', function () {
-        moveAToB(spriteC, spriteD);
-        expect(spriteA.collide(groupCD)).to.be.false;
-      });
-
-      it('true if sprite overlaps first sprite in group', function () {
-        moveAToB(spriteA, spriteC);
-        expect(spriteA.collide(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps last sprite in group', function () {
-        moveAToB(spriteA, spriteD);
-        expect(spriteA.collide(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps every sprite in group', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        expect(spriteA.collide(groupCD)).to.be.true;
-      });
-
-      it('does not overlap self when checking own group', function () {
-        expect(spriteA.collide(groupAB)).to.be.false;
-      });
-
-      it('can overlap with other sprites in own group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.collide(groupAB)).to.be.true;
-      });
-
-      it('does not call callback when not overlapping any sprites', function () {
-        spriteA.collide(groupCD, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      it('calls callback once when overlapping one sprite', function () {
-        moveAToB(spriteC, spriteA);
-        spriteA.collide(groupCD, testCallback);
-        expect(callCount).to.equal(1);
-      });
-
-      it('calls callback twice when overlapping two sprites', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        spriteA.collide(groupCD, testCallback);
-        expect(callCount).to.equal(1);
-        // Note: The first collision (A-C) displaces A, so the second collision
-        // (A-D) doesn't happen.
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          spriteA.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          spriteA.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
-
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          spriteA.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name]]);
-          // Note: The first collision (A-C) displaces A, so the second collision
-          // (A-D) doesn't happen.
-        });
-      });
-    });
-
-    describe('bounce(sprite)', function () {
-      it('false if sprites do not overlap', function () {
-        expect(spriteA.bounce(spriteB)).to.be.false;
-        expect(spriteB.bounce(spriteA)).to.be.false;
-      });
-
-      it('true if sprites overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.bounce(spriteB)).to.be.true;
-
-        moveAToB(spriteA, spriteB);
-        expect(spriteB.bounce(spriteA)).to.be.true;
-      });
-
-      it('calls callback once if sprites overlap', function () {
-        expect(callCount).to.equal(0);
-
-        moveAToB(spriteA, spriteB);
-        spriteA.bounce(spriteB, testCallback);
-        expect(callCount).to.equal(1);
-
-        moveAToB(spriteA, spriteB);
-        spriteB.bounce(spriteA, testCallback);
-        expect(callCount).to.equal(2);
-      });
-
-      it('does not call callback if sprites do not overlap', function () {
-        expect(callCount).to.equal(0);
-        spriteA.bounce(spriteB, testCallback);
-        expect(callCount).to.equal(0);
-        spriteB.bounce(spriteA, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-B', function () {
-          moveAToB(spriteA, spriteB);
-          spriteA.bounce(spriteB, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
-        });
-
-        it('B-A', function () {
-          moveAToB(spriteA, spriteB);
-          spriteB.bounce(spriteA, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
-        });
-      });
-    });
-
-    describe('bounce(group)', function () {
-      it('false if sprite does not overlap any sprites in group', function () {
-        expect(spriteA.bounce(groupCD)).to.be.false;
-      });
-
-      it('does not check against sprites not in target group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.bounce(groupCD)).to.be.false;
-      });
-
-      it('does not care if sprites in target group overlap each other', function () {
-        moveAToB(spriteC, spriteD);
-        expect(spriteA.bounce(groupCD)).to.be.false;
-      });
-
-      it('true if sprite overlaps first sprite in group', function () {
-        moveAToB(spriteA, spriteC);
-        expect(spriteA.bounce(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps last sprite in group', function () {
-        moveAToB(spriteA, spriteD);
-        expect(spriteA.bounce(groupCD)).to.be.true;
-      });
-
-      it('true if sprite overlaps every sprite in group', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        expect(spriteA.bounce(groupCD)).to.be.true;
-      });
-
-      it('does not overlap self when checking own group', function () {
-        expect(spriteA.bounce(groupAB)).to.be.false;
-      });
-
-      it('can overlap with other sprites in own group', function () {
-        moveAToB(spriteA, spriteB);
-        expect(spriteA.bounce(groupAB)).to.be.true;
-      });
-
-      it('does not call callback when not overlapping any sprites', function () {
-        spriteA.bounce(groupCD, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      it('calls callback once when overlapping one sprite', function () {
-        moveAToB(spriteC, spriteA);
-        spriteA.bounce(groupCD, testCallback);
-        expect(callCount).to.equal(1);
-      });
-
-      it('calls callback twice when overlapping two sprites', function () {
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
-        spriteA.bounce(groupCD, testCallback);
-        expect(callCount).to.equal(1);
-        // Note: The first collision (A-C) displaces A, so the second collision
-        // (A-D) doesn't happen.
-      });
-
-      describe('passes collider and collidee to callback', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          spriteA.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          spriteA.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
-
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          spriteA.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name]]);
-          // Note: The first collision (A-C) displaces A, so the second collision
-          // (A-D) doesn't happen.
-        });
+        expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
       });
     });
   });
 
-  describe('group', function () {
-    describe('overlap(sprite)', function () {
-      it('false if no sprites overlap', function () {
-        expect(groupAB.overlap(spriteC)).to.be.false;
-      });
+  describe('sprite.overlap(group)', function () {
+    it('false if sprite does not overlap any sprites in group', function () {
+      expect(spriteA.overlap(groupCD)).to.be.false;
+    });
 
-      it('false if no sprite in group overlaps target sprite', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.overlap(spriteC)).to.be.false;
-      });
+    it('does not check against sprites not in target group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.overlap(groupCD)).to.be.false;
+    });
 
-      it('true if all sprites in group overlap target sprite', function () {
+    it('does not care if sprites in target group overlap each other', function () {
+      moveAToB(spriteC, spriteD);
+      expect(spriteA.overlap(groupCD)).to.be.false;
+    });
+
+    it('true if sprite overlaps first sprite in group', function () {
+      moveAToB(spriteA, spriteC);
+      expect(spriteA.overlap(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps last sprite in group', function () {
+      moveAToB(spriteA, spriteD);
+      expect(spriteA.overlap(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps every sprite in group', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expect(spriteA.overlap(groupCD)).to.be.true;
+    });
+
+    it('does not overlap self when checking own group', function () {
+      expect(spriteA.overlap(groupAB)).to.be.false;
+    });
+
+    it('can overlap with other sprites in own group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.overlap(groupAB)).to.be.true;
+    });
+
+    it('does not call callback when not overlapping any sprites', function () {
+      spriteA.overlap(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    it('calls callback once when overlapping one sprite', function () {
+      moveAToB(spriteC, spriteA);
+      spriteA.overlap(groupCD, testCallback);
+      expect(callCount).to.equal(1);
+    });
+
+    it('calls callback twice when overlapping two sprites', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      spriteA.overlap(groupCD, testCallback);
+      expect(callCount).to.equal(2);
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-C', function () {
         moveAToB(spriteA, spriteC);
-        moveAToB(spriteB, spriteC);
+        spriteA.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+      });
+
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        spriteA.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+      });
+
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name]]);
+      });
+    });
+  });
+
+  describe('sprite.displace(sprite)', function () {
+    it('false if sprites do not overlap', function () {
+      expect(spriteA.displace(spriteB)).to.be.false;
+      expect(spriteB.displace(spriteA)).to.be.false;
+    });
+
+    it('true if sprites overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.displace(spriteB)).to.be.true;
+
+      moveAToB(spriteA, spriteB);
+      expect(spriteB.displace(spriteA)).to.be.true;
+    });
+
+    it('calls callback once if sprites overlap', function () {
+      expect(callCount).to.equal(0);
+
+      moveAToB(spriteA, spriteB);
+      spriteA.displace(spriteB, testCallback);
+      expect(callCount).to.equal(1);
+
+      moveAToB(spriteA, spriteB);
+      spriteB.displace(spriteA, testCallback);
+      expect(callCount).to.equal(2);
+    });
+
+    it('does not call callback if sprites do not overlap', function () {
+      expect(callCount).to.equal(0);
+      spriteA.displace(spriteB, testCallback);
+      expect(callCount).to.equal(0);
+      spriteB.displace(spriteA, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-B', function () {
+        moveAToB(spriteA, spriteB);
+        spriteA.displace(spriteB, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+      });
+
+      it('B-A', function () {
+        moveAToB(spriteA, spriteB);
+        spriteB.displace(spriteA, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
+      });
+    });
+  });
+
+  describe('sprite.displace(group)', function () {
+    it('false if sprite does not overlap any sprites in group', function () {
+      expect(spriteA.displace(groupCD)).to.be.false;
+    });
+
+    it('does not check against sprites not in target group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.displace(groupCD)).to.be.false;
+    });
+
+    it('does not care if sprites in target group overlap each other', function () {
+      moveAToB(spriteC, spriteD);
+      expect(spriteA.displace(groupCD)).to.be.false;
+    });
+
+    it('true if sprite overlaps first sprite in group', function () {
+      moveAToB(spriteA, spriteC);
+      expect(spriteA.displace(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps last sprite in group', function () {
+      moveAToB(spriteA, spriteD);
+      expect(spriteA.displace(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps every sprite in group', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expect(spriteA.displace(groupCD)).to.be.true;
+    });
+
+    it('does not overlap self when checking own group', function () {
+      expect(spriteA.displace(groupAB)).to.be.false;
+    });
+
+    it('can overlap with other sprites in own group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.displace(groupAB)).to.be.true;
+    });
+
+    it('does not call callback when not overlapping any sprites', function () {
+      spriteA.displace(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    it('calls callback once when overlapping one sprite', function () {
+      moveAToB(spriteC, spriteA);
+      spriteA.displace(groupCD, testCallback);
+      expect(callCount).to.equal(1);
+    });
+
+    it('calls callback twice when overlapping two sprites', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      spriteA.displace(groupCD, testCallback);
+      expect(callCount).to.equal(2);
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        spriteA.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+      });
+
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        spriteA.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+      });
+
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name]]);
+      });
+    });
+  });
+
+  describe('sprite.collide(sprite)', function () {
+    it('false if sprites do not overlap', function () {
+      expect(spriteA.collide(spriteB)).to.be.false;
+      expect(spriteB.collide(spriteA)).to.be.false;
+    });
+
+    it('true if sprites overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.collide(spriteB)).to.be.true;
+
+      moveAToB(spriteA, spriteB);
+      expect(spriteB.collide(spriteA)).to.be.true;
+    });
+
+    it('calls callback once if sprites overlap', function () {
+      expect(callCount).to.equal(0);
+
+      moveAToB(spriteA, spriteB);
+      spriteA.collide(spriteB, testCallback);
+      expect(callCount).to.equal(1);
+
+      moveAToB(spriteA, spriteB);
+      spriteB.collide(spriteA, testCallback);
+      expect(callCount).to.equal(2);
+    });
+
+    it('does not call callback if sprites do not overlap', function () {
+      expect(callCount).to.equal(0);
+      spriteA.collide(spriteB, testCallback);
+      expect(callCount).to.equal(0);
+      spriteB.collide(spriteA, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-B', function () {
+        moveAToB(spriteA, spriteB);
+        spriteA.collide(spriteB, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+      });
+
+      it('B-A', function () {
+        moveAToB(spriteA, spriteB);
+        spriteB.collide(spriteA, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
+      });
+    });
+  });
+
+  describe('sprite.collide(group)', function () {
+    it('false if sprite does not overlap any sprites in group', function () {
+      expect(spriteA.collide(groupCD)).to.be.false;
+    });
+
+    it('does not check against sprites not in target group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.collide(groupCD)).to.be.false;
+    });
+
+    it('does not care if sprites in target group overlap each other', function () {
+      moveAToB(spriteC, spriteD);
+      expect(spriteA.collide(groupCD)).to.be.false;
+    });
+
+    it('true if sprite overlaps first sprite in group', function () {
+      moveAToB(spriteA, spriteC);
+      expect(spriteA.collide(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps last sprite in group', function () {
+      moveAToB(spriteA, spriteD);
+      expect(spriteA.collide(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps every sprite in group', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expect(spriteA.collide(groupCD)).to.be.true;
+    });
+
+    it('does not overlap self when checking own group', function () {
+      expect(spriteA.collide(groupAB)).to.be.false;
+    });
+
+    it('can overlap with other sprites in own group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.collide(groupAB)).to.be.true;
+    });
+
+    it('does not call callback when not overlapping any sprites', function () {
+      spriteA.collide(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    it('calls callback once when overlapping one sprite', function () {
+      moveAToB(spriteC, spriteA);
+      spriteA.collide(groupCD, testCallback);
+      expect(callCount).to.equal(1);
+    });
+
+    it('calls callback twice when overlapping two sprites', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      spriteA.collide(groupCD, testCallback);
+      expect(callCount).to.equal(1);
+      // Note: The first collision (A-C) displaces A, so the second collision
+      // (A-D) doesn't happen.
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        spriteA.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+      });
+
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        spriteA.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+      });
+
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name]]);
+        // Note: The first collision (A-C) displaces A, so the second collision
+        // (A-D) doesn't happen.
+      });
+    });
+  });
+
+  describe('sprite.bounce(sprite)', function () {
+    it('false if sprites do not overlap', function () {
+      expect(spriteA.bounce(spriteB)).to.be.false;
+      expect(spriteB.bounce(spriteA)).to.be.false;
+    });
+
+    it('true if sprites overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.bounce(spriteB)).to.be.true;
+
+      moveAToB(spriteA, spriteB);
+      expect(spriteB.bounce(spriteA)).to.be.true;
+    });
+
+    it('calls callback once if sprites overlap', function () {
+      expect(callCount).to.equal(0);
+
+      moveAToB(spriteA, spriteB);
+      spriteA.bounce(spriteB, testCallback);
+      expect(callCount).to.equal(1);
+
+      moveAToB(spriteA, spriteB);
+      spriteB.bounce(spriteA, testCallback);
+      expect(callCount).to.equal(2);
+    });
+
+    it('does not call callback if sprites do not overlap', function () {
+      expect(callCount).to.equal(0);
+      spriteA.bounce(spriteB, testCallback);
+      expect(callCount).to.equal(0);
+      spriteB.bounce(spriteA, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-B', function () {
+        moveAToB(spriteA, spriteB);
+        spriteA.bounce(spriteB, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+      });
+
+      it('B-A', function () {
+        moveAToB(spriteA, spriteB);
+        spriteB.bounce(spriteA, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
+      });
+    });
+  });
+
+  describe('sprite.bounce(group)', function () {
+    it('false if sprite does not overlap any sprites in group', function () {
+      expect(spriteA.bounce(groupCD)).to.be.false;
+    });
+
+    it('does not check against sprites not in target group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.bounce(groupCD)).to.be.false;
+    });
+
+    it('does not care if sprites in target group overlap each other', function () {
+      moveAToB(spriteC, spriteD);
+      expect(spriteA.bounce(groupCD)).to.be.false;
+    });
+
+    it('true if sprite overlaps first sprite in group', function () {
+      moveAToB(spriteA, spriteC);
+      expect(spriteA.bounce(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps last sprite in group', function () {
+      moveAToB(spriteA, spriteD);
+      expect(spriteA.bounce(groupCD)).to.be.true;
+    });
+
+    it('true if sprite overlaps every sprite in group', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expect(spriteA.bounce(groupCD)).to.be.true;
+    });
+
+    it('does not overlap self when checking own group', function () {
+      expect(spriteA.bounce(groupAB)).to.be.false;
+    });
+
+    it('can overlap with other sprites in own group', function () {
+      moveAToB(spriteA, spriteB);
+      expect(spriteA.bounce(groupAB)).to.be.true;
+    });
+
+    it('does not call callback when not overlapping any sprites', function () {
+      spriteA.bounce(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    it('calls callback once when overlapping one sprite', function () {
+      moveAToB(spriteC, spriteA);
+      spriteA.bounce(groupCD, testCallback);
+      expect(callCount).to.equal(1);
+    });
+
+    it('calls callback twice when overlapping two sprites', function () {
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      spriteA.bounce(groupCD, testCallback);
+      expect(callCount).to.equal(1);
+      // Note: The first collision (A-C) displaces A, so the second collision
+      // (A-D) doesn't happen.
+    });
+
+    describe('passes collider and collidee to callback', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        spriteA.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+      });
+
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        spriteA.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+      });
+
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name]]);
+        // Note: The first collision (A-C) displaces A, so the second collision
+        // (A-D) doesn't happen.
+      });
+    });
+  });
+
+  describe('group.overlap(sprite)', function () {
+    it('false if no sprites overlap', function () {
+      expect(groupAB.overlap(spriteC)).to.be.false;
+    });
+
+    it('false if no sprite in group overlaps target sprite', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.overlap(spriteC)).to.be.false;
+    });
+
+    it('true if all sprites in group overlap target sprite', function () {
+      moveAToB(spriteA, spriteC);
+      moveAToB(spriteB, spriteC);
+      expect(groupAB.overlap(spriteC)).to.be.true;
+    });
+
+    describe('true if any sprites in group overlap target sprite', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
         expect(groupAB.overlap(spriteC)).to.be.true;
       });
 
-      describe('true if any sprites in group overlap target sprite', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expect(groupAB.overlap(spriteC)).to.be.true;
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expect(groupAB.overlap(spriteC)).to.be.true;
-        });
-      });
-
-      it('does not call callback when not overlapping sprite', function () {
-        groupAB.overlap(spriteC, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback for each overlap', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.overlap(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.overlap(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C', function () {
-          moveAToB(spriteA, spriteC);
-          moveAToB(spriteB, spriteC);
-          groupAB.overlap(spriteC, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-        });
+      it('B overlaps C', function () {
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.overlap(spriteC)).to.be.true;
       });
     });
 
-    describe('overlap(group)', function () {
-      function expectGroupsOverlap(outcome) {
-        expect(groupAB.overlap(groupCD)).to.equal(outcome);
-        expect(groupCD.overlap(groupAB)).to.equal(outcome);
-      }
+    it('does not call callback when not overlapping sprite', function () {
+      groupAB.overlap(spriteC, testCallback);
+      expect(callCount).to.equal(0);
+    });
 
-      it('false if no sprites overlap', function () {
-        expectGroupsOverlap(false);
+    describe('passes collider and collidee to callback for each overlap', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        groupAB.overlap(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
-        moveAToB(spriteA, spriteB);
-        moveAToB(spriteC, spriteD);
-        expectGroupsOverlap(false);
+      it('B-C', function () {
+        moveAToB(spriteB, spriteC);
+        groupAB.overlap(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('true if all sprites in group AB overlap all sprites in group CD', function () {
-        moveAToB(spriteB, spriteA);
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
+      it('A-B-C', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        groupAB.overlap(spriteC, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+      });
+    });
+  });
+
+  describe('group.overlap(group)', function () {
+    function expectGroupsOverlap(outcome) {
+      expect(groupAB.overlap(groupCD)).to.equal(outcome);
+      expect(groupCD.overlap(groupAB)).to.equal(outcome);
+    }
+
+    it('false if no sprites overlap', function () {
+      expectGroupsOverlap(false);
+    });
+
+    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+      moveAToB(spriteA, spriteB);
+      moveAToB(spriteC, spriteD);
+      expectGroupsOverlap(false);
+    });
+
+    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+      moveAToB(spriteB, spriteA);
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expectGroupsOverlap(true);
+    });
+
+    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
         expectGroupsOverlap(true);
       });
 
-      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expectGroupsOverlap(true);
-        });
-
-        it('A overlaps D', function () {
-          moveAToB(spriteA, spriteD);
-          expectGroupsOverlap(true);
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expectGroupsOverlap(true);
-        });
-
-        it('B overlaps D', function () {
-          moveAToB(spriteB, spriteD);
-          expectGroupsOverlap(true);
-        });
+      it('A overlaps D', function () {
+        moveAToB(spriteA, spriteD);
+        expectGroupsOverlap(true);
       });
 
-      it('group does not overlap self if no sprites within group overlap', function () {
-        expect(groupAB.overlap(groupAB)).to.be.false;
+      it('B overlaps C', function () {
+        moveAToB(spriteB, spriteC);
+        expectGroupsOverlap(true);
       });
 
-      it('group overlaps self if two different sprites within group overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.overlap(groupAB)).to.be.true;
-      });
-
-      it('does not call callback when not overlapping any sprites', function () {
-        groupAB.overlap(groupCD, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback for each pair', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
-
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
-
-        it('B-D', function () {
-          moveAToB(spriteB, spriteD);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
-        });
-
-        it('A-B-C', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteD.name]]);
-        });
-
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteA.name, spriteD.name]]);
-        });
-
-        it('B-C-D', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteB);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteB.name, spriteC.name],
-            [spriteB.name, spriteD.name]]);
-        });
-
-        it('A-C, B-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteB);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteD.name]]);
-        });
-
-        it('A-D, B-C', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteA);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.overlap(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteC.name],
-            [spriteB.name, spriteD.name]]);
-        });
+      it('B overlaps D', function () {
+        moveAToB(spriteB, spriteD);
+        expectGroupsOverlap(true);
       });
     });
 
-    describe('displace(sprite)', function () {
-      it('false if no sprites overlap', function () {
-        expect(groupAB.displace(spriteC)).to.be.false;
-      });
+    it('group does not overlap self if no sprites within group overlap', function () {
+      expect(groupAB.overlap(groupAB)).to.be.false;
+    });
 
-      it('false if no sprite in group overlaps target sprite', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.displace(spriteC)).to.be.false;
-      });
+    it('group overlaps self if two different sprites within group overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.overlap(groupAB)).to.be.true;
+    });
 
-      it('true if all sprites in group overlap target sprite', function () {
+    it('does not call callback when not overlapping any sprites', function () {
+      groupAB.overlap(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback for each pair', function () {
+      it('A-C', function () {
         moveAToB(spriteA, spriteC);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+      });
+
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+      });
+
+      it('B-C', function () {
         moveAToB(spriteB, spriteC);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+      });
+
+      it('B-D', function () {
+        moveAToB(spriteB, spriteD);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+      });
+
+      it('A-B-C', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+      });
+
+      it('A-B-D', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteD.name]]);
+      });
+
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name]]);
+      });
+
+      it('B-C-D', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteB);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteB.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+      });
+
+      it('A-C, B-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteB);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+      });
+
+      it('A-D, B-C', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteA);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteC.name]]);
+      });
+
+      it('A-B-C-D', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.overlap(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+      });
+    });
+  });
+
+  describe('group.displace(sprite)', function () {
+    it('false if no sprites overlap', function () {
+      expect(groupAB.displace(spriteC)).to.be.false;
+    });
+
+    it('false if no sprite in group overlaps target sprite', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.displace(spriteC)).to.be.false;
+    });
+
+    it('true if all sprites in group overlap target sprite', function () {
+      moveAToB(spriteA, spriteC);
+      moveAToB(spriteB, spriteC);
+      expect(groupAB.displace(spriteC)).to.be.true;
+    });
+
+    describe('true if any sprites in group overlap target sprite', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
         expect(groupAB.displace(spriteC)).to.be.true;
       });
 
-      describe('true if any sprites in group overlap target sprite', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expect(groupAB.displace(spriteC)).to.be.true;
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expect(groupAB.displace(spriteC)).to.be.true;
-        });
-      });
-
-      it('does not call callback when not overlapping sprite', function () {
-        groupAB.displace(spriteC, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback for each overlap', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.displace(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.displace(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C', function () {
-          moveAToB(spriteA, spriteC);
-          moveAToB(spriteB, spriteC);
-          groupAB.displace(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-          // Note: First collision (A-C) displaces C away from A and B,
-          //       so the second collision (B-C) never happens.
-        });
+      it('B overlaps C', function () {
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.displace(spriteC)).to.be.true;
       });
     });
 
-    describe('displace(group)', function () {
-      it('false if no sprites overlap', function () {
-        expect(groupAB.displace(groupCD)).to.be.false;
+    it('does not call callback when not overlapping sprite', function () {
+      groupAB.displace(spriteC, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback for each overlap', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        groupAB.displace(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
-        moveAToB(spriteA, spriteB);
-        moveAToB(spriteC, spriteD);
-        expect(groupAB.displace(groupCD)).to.be.false;
+      it('B-C', function () {
+        moveAToB(spriteB, spriteC);
+        groupAB.displace(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('true if all sprites in group AB overlap all sprites in group CD', function () {
-        moveAToB(spriteB, spriteA);
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
+      it('A-B-C', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        groupAB.displace(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        // Note: First collision (A-C) displaces C away from A and B,
+        //       so the second collision (B-C) never happens.
+      });
+    });
+  });
+
+  describe('group.displace(group)', function () {
+    it('false if no sprites overlap', function () {
+      expect(groupAB.displace(groupCD)).to.be.false;
+    });
+
+    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+      moveAToB(spriteA, spriteB);
+      moveAToB(spriteC, spriteD);
+      expect(groupAB.displace(groupCD)).to.be.false;
+    });
+
+    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+      moveAToB(spriteB, spriteA);
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expect(groupAB.displace(groupCD)).to.be.true;
+    });
+
+    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
         expect(groupAB.displace(groupCD)).to.be.true;
       });
 
-      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expect(groupAB.displace(groupCD)).to.be.true;
-        });
-
-        it('A overlaps D', function () {
-          moveAToB(spriteA, spriteD);
-          expect(groupAB.displace(groupCD)).to.be.true;
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expect(groupAB.displace(groupCD)).to.be.true;
-        });
-
-        it('B overlaps D', function () {
-          moveAToB(spriteB, spriteD);
-          expect(groupAB.displace(groupCD)).to.be.true;
-        });
+      it('A overlaps D', function () {
+        moveAToB(spriteA, spriteD);
+        expect(groupAB.displace(groupCD)).to.be.true;
       });
 
-      it('group does not overlap self if no sprites within group overlap', function () {
-        expect(groupAB.displace(groupAB)).to.be.false;
+      it('B overlaps C', function () {
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.displace(groupCD)).to.be.true;
       });
 
-      it('group overlaps self if two different sprites within group overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.displace(groupAB)).to.be.true;
-      });
-
-      it('does not call callback when not overlapping any sprites', function () {
-        groupAB.displace(groupCD, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback for each pair', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
-
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
-
-        it('B-D', function () {
-          moveAToB(spriteB, spriteD);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
-        });
-
-        it('A-B-C', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-          // Note: First collision (A-C) displaces C away from A and B,
-          //       so the second collision (B-C) never happens.
-        });
-
-        it('A-B-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-          // Note: First collision (A-D) displaces D away from A and B,
-          //       so the second collision (B-D) never happens.
-        });
-
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteA.name, spriteD.name]]);
-        });
-
-        it('B-C-D', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteB);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteB.name, spriteC.name],
-            [spriteB.name, spriteD.name]]);
-        });
-
-        it('A-C, B-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteB);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteD.name]]);
-        });
-
-        it('A-D, B-C', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteA);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.displace(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteA.name, spriteD.name]]);
-          // Note: First collision (A-C) and second collision (A-D)
-          // displace C and D away from A and B,
-          // so the third and fourth collisions (B-C and B-D) never happen.
-        });
+      it('B overlaps D', function () {
+        moveAToB(spriteB, spriteD);
+        expect(groupAB.displace(groupCD)).to.be.true;
       });
     });
 
-    describe('collide(sprite)', function () {
-      it('false if no sprites overlap', function () {
-        expect(groupAB.collide(spriteC)).to.be.false;
-      });
+    it('group does not overlap self if no sprites within group overlap', function () {
+      expect(groupAB.displace(groupAB)).to.be.false;
+    });
 
-      it('false if no sprite in group overlaps target sprite', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.collide(spriteC)).to.be.false;
-      });
+    it('group overlaps self if two different sprites within group overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.displace(groupAB)).to.be.true;
+    });
 
-      it('true if all sprites in group overlap target sprite', function () {
+    it('does not call callback when not overlapping any sprites', function () {
+      groupAB.displace(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback for each pair', function () {
+      it('A-C', function () {
         moveAToB(spriteA, spriteC);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+      });
+
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+      });
+
+      it('B-C', function () {
         moveAToB(spriteB, spriteC);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+      });
+
+      it('B-D', function () {
+        moveAToB(spriteB, spriteD);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+      });
+
+      it('A-B-C', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        // Note: First collision (A-C) displaces C away from A and B,
+        //       so the second collision (B-C) never happens.
+      });
+
+      it('A-B-D', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        // Note: First collision (A-D) displaces D away from A and B,
+        //       so the second collision (B-D) never happens.
+      });
+
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name]]);
+      });
+
+      it('B-C-D', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteB);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteB.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+      });
+
+      it('A-C, B-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteB);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+      });
+
+      it('A-D, B-C', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteA);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteC.name]]);
+      });
+
+      it('A-B-C-D', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.displace(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name]]);
+        // Note: First collision (A-C) and second collision (A-D)
+        // displace C and D away from A and B,
+        // so the third and fourth collisions (B-C and B-D) never happen.
+      });
+    });
+  });
+
+  describe('group.collide(sprite)', function () {
+    it('false if no sprites overlap', function () {
+      expect(groupAB.collide(spriteC)).to.be.false;
+    });
+
+    it('false if no sprite in group overlaps target sprite', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.collide(spriteC)).to.be.false;
+    });
+
+    it('true if all sprites in group overlap target sprite', function () {
+      moveAToB(spriteA, spriteC);
+      moveAToB(spriteB, spriteC);
+      expect(groupAB.collide(spriteC)).to.be.true;
+    });
+
+    describe('true if any sprites in group overlap target sprite', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
         expect(groupAB.collide(spriteC)).to.be.true;
       });
 
-      describe('true if any sprites in group overlap target sprite', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expect(groupAB.collide(spriteC)).to.be.true;
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expect(groupAB.collide(spriteC)).to.be.true;
-        });
-      });
-
-      it('does not call callback when not overlapping sprite', function () {
-        groupAB.collide(spriteC, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback for each overlap', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.collide(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.collide(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C', function () {
-          moveAToB(spriteA, spriteC);
-          moveAToB(spriteB, spriteC);
-          groupAB.collide(spriteC, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-        });
+      it('B overlaps C', function () {
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.collide(spriteC)).to.be.true;
       });
     });
 
-    describe('collide(group)', function () {
-      it('false if no sprites overlap', function () {
-        expect(groupAB.collide(groupCD)).to.be.false;
+    it('does not call callback when not overlapping sprite', function () {
+      groupAB.collide(spriteC, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback for each overlap', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        groupAB.collide(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
-        moveAToB(spriteA, spriteB);
-        moveAToB(spriteC, spriteD);
-        expect(groupAB.collide(groupCD)).to.be.false;
+      it('B-C', function () {
+        moveAToB(spriteB, spriteC);
+        groupAB.collide(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('true if all sprites in group AB overlap all sprites in group CD', function () {
-        moveAToB(spriteB, spriteA);
-        moveAToB(spriteC, spriteA);
-        moveAToB(spriteD, spriteA);
+      it('A-B-C', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        groupAB.collide(spriteC, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+      });
+    });
+  });
+
+  describe('group.collide(group)', function () {
+    it('false if no sprites overlap', function () {
+      expect(groupAB.collide(groupCD)).to.be.false;
+    });
+
+    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+      moveAToB(spriteA, spriteB);
+      moveAToB(spriteC, spriteD);
+      expect(groupAB.collide(groupCD)).to.be.false;
+    });
+
+    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+      moveAToB(spriteB, spriteA);
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expect(groupAB.collide(groupCD)).to.be.true;
+    });
+
+    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
         expect(groupAB.collide(groupCD)).to.be.true;
       });
 
-      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expect(groupAB.collide(groupCD)).to.be.true;
-        });
-
-        it('A overlaps D', function () {
-          moveAToB(spriteA, spriteD);
-          expect(groupAB.collide(groupCD)).to.be.true;
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expect(groupAB.collide(groupCD)).to.be.true;
-        });
-
-        it('B overlaps D', function () {
-          moveAToB(spriteB, spriteD);
-          expect(groupAB.collide(groupCD)).to.be.true;
-        });
+      it('A overlaps D', function () {
+        moveAToB(spriteA, spriteD);
+        expect(groupAB.collide(groupCD)).to.be.true;
       });
 
-      it('group does not overlap self if no sprites within group overlap', function () {
-        expect(groupAB.collide(groupAB)).to.be.false;
-      });
-
-      it('group overlaps self if two different sprites within group overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.collide(groupAB)).to.be.true;
-      });
-
-      it('does not call callback when not overlapping any sprites', function () {
-        groupAB.collide(groupCD, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback for each pair', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
-
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
-
-        it('B-D', function () {
-          moveAToB(spriteB, spriteD);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
-        });
-
-        it('A-B-C', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteD.name]]);
-        });
-
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name]]);
-          // Note: due to displacement, only the first collision occurs.
-        });
-
-        it('B-C-D', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteB);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteB.name, spriteC.name]]);
-          // Note: due to displacement, only the first collision occurs.
-        });
-
-        it('A-C, B-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteB);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteD.name]]);
-        });
-
-        it('A-D, B-C', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteA);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.collide(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-          // Note: Due to displacement, only two collisions occur.
-        });
-      });
-    });
-
-    describe('bounce(sprite)', function () {
-      it('false if no sprites overlap', function () {
-        expect(groupAB.bounce(spriteC)).to.be.false;
-      });
-
-      it('false if no sprite in group overlaps target sprite', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.bounce(spriteC)).to.be.false;
-      });
-
-      it('true if all sprites in group overlap target sprite', function () {
-        moveAToB(spriteA, spriteC);
+      it('B overlaps C', function () {
         moveAToB(spriteB, spriteC);
-        expect(groupAB.bounce(spriteC)).to.be.true;
+        expect(groupAB.collide(groupCD)).to.be.true;
       });
 
-      describe('true if any sprites in group overlap target sprite', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expect(groupAB.bounce(spriteC)).to.be.true;
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expect(groupAB.bounce(spriteC)).to.be.true;
-        });
-      });
-
-      it('does not call callback when not overlapping sprite', function () {
-        groupAB.bounce(spriteC, testCallback);
-        expect(callCount).to.equal(0);
-      });
-
-      describe('passes collider and collidee to callback for each overlap', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.bounce(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
-
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.bounce(spriteC, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C', function () {
-          moveAToB(spriteA, spriteC);
-          moveAToB(spriteB, spriteC);
-          groupAB.bounce(spriteC, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-        });
+      it('B overlaps D', function () {
+        moveAToB(spriteB, spriteD);
+        expect(groupAB.collide(groupCD)).to.be.true;
       });
     });
 
-    describe('bounce(group)', function () {
-      it('false if no sprites overlap', function () {
-        expect(groupAB.bounce(groupCD)).to.be.false;
+    it('group does not overlap self if no sprites within group overlap', function () {
+      expect(groupAB.collide(groupAB)).to.be.false;
+    });
+
+    it('group overlaps self if two different sprites within group overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.collide(groupAB)).to.be.true;
+    });
+
+    it('does not call callback when not overlapping any sprites', function () {
+      groupAB.collide(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback for each pair', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
-        moveAToB(spriteA, spriteB);
-        moveAToB(spriteC, spriteD);
-        expect(groupAB.bounce(groupCD)).to.be.false;
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('true if all sprites in group AB overlap all sprites in group CD', function () {
+      it('B-C', function () {
+        moveAToB(spriteB, spriteC);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+      });
+
+      it('B-D', function () {
+        moveAToB(spriteB, spriteD);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+      });
+
+      it('A-B-C', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+      });
+
+      it('A-B-D', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteD.name]]);
+      });
+
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name]]);
+        // Note: due to displacement, only the first collision occurs.
+      });
+
+      it('B-C-D', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteB);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteB.name, spriteC.name]]);
+        // Note: due to displacement, only the first collision occurs.
+      });
+
+      it('A-C, B-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteB);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+      });
+
+      it('A-D, B-C', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteA);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteC.name]]);
+      });
+
+      it('A-B-C-D', function () {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
+        groupAB.collide(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+        // Note: Due to displacement, only two collisions occur.
+      });
+    });
+  });
+
+  describe('group.bounce(sprite)', function () {
+    it('false if no sprites overlap', function () {
+      expect(groupAB.bounce(spriteC)).to.be.false;
+    });
+
+    it('false if no sprite in group overlaps target sprite', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.bounce(spriteC)).to.be.false;
+    });
+
+    it('true if all sprites in group overlap target sprite', function () {
+      moveAToB(spriteA, spriteC);
+      moveAToB(spriteB, spriteC);
+      expect(groupAB.bounce(spriteC)).to.be.true;
+    });
+
+    describe('true if any sprites in group overlap target sprite', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
+        expect(groupAB.bounce(spriteC)).to.be.true;
+      });
+
+      it('B overlaps C', function () {
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.bounce(spriteC)).to.be.true;
+      });
+    });
+
+    it('does not call callback when not overlapping sprite', function () {
+      groupAB.bounce(spriteC, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback for each overlap', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
+        groupAB.bounce(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+      });
+
+      it('B-C', function () {
+        moveAToB(spriteB, spriteC);
+        groupAB.bounce(spriteC, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+      });
+
+      it('A-B-C', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        groupAB.bounce(spriteC, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+      });
+    });
+  });
+
+  describe('group.bounce(group)', function () {
+    it('false if no sprites overlap', function () {
+      expect(groupAB.bounce(groupCD)).to.be.false;
+    });
+
+    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+      moveAToB(spriteA, spriteB);
+      moveAToB(spriteC, spriteD);
+      expect(groupAB.bounce(groupCD)).to.be.false;
+    });
+
+    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+      moveAToB(spriteB, spriteA);
+      moveAToB(spriteC, spriteA);
+      moveAToB(spriteD, spriteA);
+      expect(groupAB.bounce(groupCD)).to.be.true;
+    });
+
+    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
+      it('A overlaps C', function () {
+        moveAToB(spriteA, spriteC);
         expect(groupAB.bounce(groupCD)).to.be.true;
       });
 
-      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-        it('A overlaps C', function () {
-          moveAToB(spriteA, spriteC);
-          expect(groupAB.bounce(groupCD)).to.be.true;
-        });
-
-        it('A overlaps D', function () {
-          moveAToB(spriteA, spriteD);
-          expect(groupAB.bounce(groupCD)).to.be.true;
-        });
-
-        it('B overlaps C', function () {
-          moveAToB(spriteB, spriteC);
-          expect(groupAB.bounce(groupCD)).to.be.true;
-        });
-
-        it('B overlaps D', function () {
-          moveAToB(spriteB, spriteD);
-          expect(groupAB.bounce(groupCD)).to.be.true;
-        });
+      it('A overlaps D', function () {
+        moveAToB(spriteA, spriteD);
+        expect(groupAB.bounce(groupCD)).to.be.true;
       });
 
-      it('group does not overlap self if no sprites within group overlap', function () {
-        expect(groupAB.bounce(groupAB)).to.be.false;
+      it('B overlaps C', function () {
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.bounce(groupCD)).to.be.true;
       });
 
-      it('group overlaps self if two different sprites within group overlap', function () {
-        moveAToB(spriteA, spriteB);
-        expect(groupAB.bounce(groupAB)).to.be.true;
+      it('B overlaps D', function () {
+        moveAToB(spriteB, spriteD);
+        expect(groupAB.bounce(groupCD)).to.be.true;
       });
+    });
 
-      it('does not call callback when not overlapping any sprites', function () {
+    it('group does not overlap self if no sprites within group overlap', function () {
+      expect(groupAB.bounce(groupAB)).to.be.false;
+    });
+
+    it('group overlaps self if two different sprites within group overlap', function () {
+      moveAToB(spriteA, spriteB);
+      expect(groupAB.bounce(groupAB)).to.be.true;
+    });
+
+    it('does not call callback when not overlapping any sprites', function () {
+      groupAB.bounce(groupCD, testCallback);
+      expect(callCount).to.equal(0);
+    });
+
+    describe('passes collider and collidee to callback for each pair', function () {
+      it('A-C', function () {
+        moveAToB(spriteA, spriteC);
         groupAB.bounce(groupCD, testCallback);
-        expect(callCount).to.equal(0);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      describe('passes collider and collidee to callback for each pair', function () {
-        it('A-C', function () {
-          moveAToB(spriteA, spriteC);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-        });
+      it('A-D', function () {
+        moveAToB(spriteA, spriteD);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+      });
 
-        it('A-D', function () {
-          moveAToB(spriteA, spriteD);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
-        });
+      it('B-C', function () {
+        moveAToB(spriteB, spriteC);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+      });
 
-        it('B-C', function () {
-          moveAToB(spriteB, spriteC);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
-        });
+      it('B-D', function () {
+        moveAToB(spriteB, spriteD);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+      });
 
-        it('B-D', function () {
-          moveAToB(spriteB, spriteD);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
-        });
+      it('A-B-C', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+      });
 
-        it('A-B-C', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-        });
+      it('A-B-D', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteD.name]]);
+      });
 
-        it('A-B-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteD.name]]);
-        });
+      it('A-C-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name]]);
+        // Note: due to displacement, only the first collision occurs.
+      });
 
-        it('A-C-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name]]);
-          // Note: due to displacement, only the first collision occurs.
-        });
+      it('B-C-D', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteB);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteB.name, spriteC.name]]);
+        // Note: due to displacement, only the first collision occurs.
+      });
 
-        it('B-C-D', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteB);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteB.name, spriteC.name]]);
-          // Note: due to displacement, only the first collision occurs.
-        });
+      it('A-C, B-D', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteB);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+      });
 
-        it('A-C, B-D', function () {
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteB);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteD.name]]);
-        });
+      it('A-D, B-C', function () {
+        moveAToB(spriteC, spriteB);
+        moveAToB(spriteD, spriteA);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteC.name]]);
+      });
 
-        it('A-D, B-C', function () {
-          moveAToB(spriteC, spriteB);
-          moveAToB(spriteD, spriteA);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteD.name],
-            [spriteB.name, spriteC.name]]);
-        });
-
-        it('A-B-C-D', function () {
-          moveAToB(spriteB, spriteA);
-          moveAToB(spriteC, spriteA);
-          moveAToB(spriteD, spriteA);
-          groupAB.bounce(groupCD, testCallback);
-          expect(pairs).to.deep.equal([
-            [spriteA.name, spriteC.name],
-            [spriteB.name, spriteC.name]]);
-          // Note: Due to displacement, only two collisions occur.
-        });
+      it('A-B-C-D', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        groupAB.bounce(groupCD, testCallback);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteB.name, spriteC.name]]);
+        // Note: Due to displacement, only two collisions occur.
       });
     });
   });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -173,7 +173,7 @@ describe('collisions', function() {
           expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
         });
 
-        it('A-C, A-D', function () {
+        it('A-C-D', function () {
           moveAToB(spriteC, spriteA);
           moveAToB(spriteD, spriteA);
           spriteA.overlap(groupCD, testCallback);
@@ -186,6 +186,63 @@ describe('collisions', function() {
   });
 
   describe('group', function () {
+    describe('overlap(sprite)', function () {
+      it('false if no sprites overlap', function () {
+        expect(groupAB.overlap(spriteC)).to.be.false;
+      });
+
+      it('false if no sprite in group overlaps target sprite', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.overlap(spriteC)).to.be.false;
+      });
+
+      it('true if all sprites in group overlap target sprite', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.overlap(spriteC)).to.be.true;
+      });
+
+      describe('true if any sprites in group overlap target sprite', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expect(groupAB.overlap(spriteC)).to.be.true;
+        });
+
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expect(groupAB.overlap(spriteC)).to.be.true;
+        });
+      });
+
+      it('does not call callback when not overlapping sprite', function () {
+        groupAB.overlap(spriteC, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback for each overlap', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.overlap(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.overlap(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C', function () {
+          moveAToB(spriteA, spriteC);
+          moveAToB(spriteB, spriteC);
+          groupAB.overlap(spriteC, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+        });
+      });
+    });
+
     describe('overlap(group)', function () {
       function expectGroupsOverlap(outcome) {
         expect(groupAB.overlap(groupCD)).to.equal(outcome);
@@ -196,20 +253,20 @@ describe('collisions', function() {
         expectGroupsOverlap(false);
       });
 
-      it('false if no sprite in group A overlaps any sprite in group B', function () {
+      it('false if no sprite in group AB overlaps any sprite in group CD', function () {
         moveAToB(spriteA, spriteB);
         moveAToB(spriteC, spriteD);
         expectGroupsOverlap(false);
       });
 
-      it('true if all sprites in group A overlap all sprites in group B', function () {
+      it('true if all sprites in group AB overlap all sprites in group CD', function () {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         expectGroupsOverlap(true);
       });
 
-      describe('true if any sprites in group A overlap any sprites in group B', function () {
+      describe('true if any sprites in group AB overlap any sprites in group CD', function () {
         it('A overlaps C', function () {
           moveAToB(spriteA, spriteC);
           expectGroupsOverlap(true);

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -192,6 +192,137 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('displace(sprite)', function () {
+      it('false if sprites do not overlap', function () {
+        expect(spriteA.displace(spriteB)).to.be.false;
+        expect(spriteB.displace(spriteA)).to.be.false;
+      });
+
+      it('true if sprites overlap', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.displace(spriteB)).to.be.true;
+
+        moveAToB(spriteA, spriteB);
+        expect(spriteB.displace(spriteA)).to.be.true;
+      });
+
+      it('calls callback once if sprites overlap', function () {
+        expect(callCount).to.equal(0);
+
+        moveAToB(spriteA, spriteB);
+        spriteA.displace(spriteB, testCallback);
+        expect(callCount).to.equal(1);
+
+        moveAToB(spriteA, spriteB);
+        spriteB.displace(spriteA, testCallback);
+        expect(callCount).to.equal(2);
+      });
+
+      it('does not call callback if sprites do not overlap', function () {
+        expect(callCount).to.equal(0);
+        spriteA.displace(spriteB, testCallback);
+        expect(callCount).to.equal(0);
+        spriteB.displace(spriteA, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback', function () {
+        it('A-B', function () {
+          moveAToB(spriteA, spriteB);
+          spriteA.displace(spriteB, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+        });
+
+        it('B-A', function () {
+          moveAToB(spriteA, spriteB);
+          spriteB.displace(spriteA, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
+        });
+      });
+    });
+
+    describe('displace(group)', function () {
+      it('false if sprite does not overlap any sprites in group', function () {
+        expect(spriteA.displace(groupCD)).to.be.false;
+      });
+
+      it('does not check against sprites not in target group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.displace(groupCD)).to.be.false;
+      });
+
+      it('does not care if sprites in target group overlap each other', function () {
+        moveAToB(spriteC, spriteD);
+        expect(spriteA.displace(groupCD)).to.be.false;
+      });
+
+      it('true if sprite overlaps first sprite in group', function () {
+        moveAToB(spriteA, spriteC);
+        expect(spriteA.displace(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps last sprite in group', function () {
+        moveAToB(spriteA, spriteD);
+        expect(spriteA.displace(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps every sprite in group', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expect(spriteA.displace(groupCD)).to.be.true;
+      });
+
+      it('does not overlap self when checking own group', function () {
+        expect(spriteA.displace(groupAB)).to.be.false;
+      });
+
+      it('can overlap with other sprites in own group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.displace(groupAB)).to.be.true;
+      });
+
+      it('does not call callback when not overlapping any sprites', function () {
+        spriteA.displace(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      it('calls callback once when overlapping one sprite', function () {
+        moveAToB(spriteC, spriteA);
+        spriteA.displace(groupCD, testCallback);
+        expect(callCount).to.equal(1);
+      });
+
+      it('calls callback twice when overlapping two sprites', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.displace(groupCD, testCallback);
+        expect(callCount).to.equal(2);
+      });
+
+      describe('passes collider and collidee to callback', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          spriteA.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          spriteA.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
+
+        it('A-C-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          spriteA.displace(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteA.name, spriteD.name]]);
+        });
+      });
+    });
   });
 
   describe('group', function () {

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -372,6 +372,91 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('collide(group)', function () {
+      it('false if sprite does not overlap any sprites in group', function () {
+        expect(spriteA.collide(groupCD)).to.be.false;
+      });
+
+      it('does not check against sprites not in target group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.collide(groupCD)).to.be.false;
+      });
+
+      it('does not care if sprites in target group overlap each other', function () {
+        moveAToB(spriteC, spriteD);
+        expect(spriteA.collide(groupCD)).to.be.false;
+      });
+
+      it('true if sprite overlaps first sprite in group', function () {
+        moveAToB(spriteA, spriteC);
+        expect(spriteA.collide(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps last sprite in group', function () {
+        moveAToB(spriteA, spriteD);
+        expect(spriteA.collide(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps every sprite in group', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expect(spriteA.collide(groupCD)).to.be.true;
+      });
+
+      it('does not overlap self when checking own group', function () {
+        expect(spriteA.collide(groupAB)).to.be.false;
+      });
+
+      it('can overlap with other sprites in own group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.collide(groupAB)).to.be.true;
+      });
+
+      it('does not call callback when not overlapping any sprites', function () {
+        spriteA.collide(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      it('calls callback once when overlapping one sprite', function () {
+        moveAToB(spriteC, spriteA);
+        spriteA.collide(groupCD, testCallback);
+        expect(callCount).to.equal(1);
+      });
+
+      it('calls callback twice when overlapping two sprites', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.collide(groupCD, testCallback);
+        expect(callCount).to.equal(1);
+        // Note: The first collision (A-C) displaces A, so the second collision
+        // (A-D) doesn't happen.
+      });
+
+      describe('passes collider and collidee to callback', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          spriteA.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          spriteA.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
+
+        it('A-C-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          spriteA.collide(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name]]);
+          // Note: The first collision (A-C) displaces A, so the second collision
+          // (A-D) doesn't happen.
+        });
+      });
+    });
   });
 
   describe('group', function () {

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -873,5 +873,62 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('collide(sprite)', function () {
+      it('false if no sprites overlap', function () {
+        expect(groupAB.collide(spriteC)).to.be.false;
+      });
+
+      it('false if no sprite in group overlaps target sprite', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.collide(spriteC)).to.be.false;
+      });
+
+      it('true if all sprites in group overlap target sprite', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.collide(spriteC)).to.be.true;
+      });
+
+      describe('true if any sprites in group overlap target sprite', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expect(groupAB.collide(spriteC)).to.be.true;
+        });
+
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expect(groupAB.collide(spriteC)).to.be.true;
+        });
+      });
+
+      it('does not call callback when not overlapping sprite', function () {
+        groupAB.collide(spriteC, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback for each overlap', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.collide(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.collide(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C', function () {
+          moveAToB(spriteA, spriteC);
+          moveAToB(spriteB, spriteC);
+          groupAB.collide(spriteC, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+        });
+      });
+    });
   });
 });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -1,8 +1,16 @@
 describe('collisions', function() {
+  const SIZE = 10;
   var pInst;
+  var countingCallback;
 
   beforeEach(function () {
     pInst = new p5(function() {});
+
+    // Count callback calls
+    countingCallback = function () {
+      countingCallback.callCount++;
+    };
+    countingCallback.callCount = 0;
   });
 
   afterEach(function () {
@@ -10,20 +18,12 @@ describe('collisions', function() {
   });
 
   describe('sprite-sprite', function () {
-    const SIZE = 10;
     var spriteA, spriteB;
-    var countingCallback;
     var argTrackingCallback;
 
     beforeEach(function () {
       spriteA = pInst.createSprite(0, 0, SIZE, SIZE);
       spriteB = pInst.createSprite(0, 0, SIZE, SIZE);
-
-      // Count callback calls
-      countingCallback = function () {
-        countingCallback.callCount++;
-      };
-      countingCallback.callCount = 0;
 
       // Remember last arguments to callback
       argTrackingCallback = function () {
@@ -82,6 +82,111 @@ describe('collisions', function() {
         expect(argTrackingCallback.lastArgs.length).to.be.at.least(2);
         expect(argTrackingCallback.lastArgs[0]).to.equal(spriteB);
         expect(argTrackingCallback.lastArgs[1]).to.equal(spriteA);
+      });
+    });
+  });
+
+  describe('sprite-group', function () {
+    var spriteA, spriteB, spriteC, spriteD;
+    var groupA;
+    var argTrackingCallback;
+
+    beforeEach(function () {
+      spriteA = pInst.createSprite(0, 0, SIZE, SIZE);
+      spriteB = pInst.createSprite(0, 0, SIZE, SIZE);
+      spriteC = pInst.createSprite(0, 0, SIZE, SIZE);
+
+      groupA = new pInst.Group();
+      groupA.add(spriteB);
+      groupA.add(spriteC);
+
+      // Remember last arguments to callback
+      argTrackingCallback = function () {
+        argTrackingCallback.lastArgs = arguments;
+      };
+    });
+
+    describe('overlap', function () {
+      it('returns true if sprite overlaps every sprite in group', function () {
+        expect(spriteA.overlap(groupA)).to.be.true;
+      });
+
+      it('returns true if sprite overlaps first sprite in group', function () {
+        spriteC.position.x += 2 * SIZE;
+        expect(spriteA.overlap(groupA)).to.be.true;
+      });
+
+      it('returns true if sprite overlaps last sprite in group', function () {
+        spriteB.position.x += 2 * SIZE;
+        expect(spriteA.overlap(groupA)).to.be.true;
+      });
+
+      it('returns false if sprite does not overlap any sprites in group', function () {
+        spriteB.position.x += 2 * SIZE;
+        spriteC.position.x += 2 * SIZE;
+        expect(spriteA.overlap(groupA)).to.be.false;
+      });
+
+      it('sprite in group can overlap with other sprites in group', function () {
+        expect(spriteB.overlap(groupA)).to.be.true;
+      });
+
+      it('sprite in group does not overlap self', function () {
+        spriteC.position.x += 2 * SIZE;
+        expect(spriteB.overlap(groupA)).to.be.false;
+      });
+
+      it('calls callback once for each overlapping sprite', function () {
+        expect(countingCallback.callCount).to.equal(0);
+        spriteA.overlap(groupA, countingCallback);
+        expect(countingCallback.callCount).to.equal(2);
+
+        countingCallback.callCount = 0;
+        spriteB.position.x += 2 * SIZE;
+        spriteA.overlap(groupA, countingCallback);
+        expect(countingCallback.callCount).to.equal(1);
+
+        countingCallback.callCount = 0;
+        spriteC.position.x += 2 * SIZE;
+        spriteA.overlap(groupA, countingCallback);
+        expect(countingCallback.callCount).to.equal(0);
+      });
+
+      it('passes collider and collidee to callback', function () {
+        spriteA.name = 'spriteA';
+        spriteB.name = 'spriteB';
+        spriteC.name = 'spriteC';
+
+        var pairs;
+        function recordPairs(a, b) {
+          pairs.push([a.name, b.name]);
+        }
+
+        // Overlaps both
+        pairs = [];
+        spriteA.overlap(groupA, recordPairs);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name], [spriteA.name, spriteC.name]]);
+
+        // Overlaps spriteB
+        pairs = [];
+        spriteB.position.x = spriteA.position.x;
+        spriteC.position.x = 2 * SIZE;
+        spriteA.overlap(groupA, recordPairs);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+
+        // Overlaps spriteC
+        pairs = [];
+        spriteB.position.x = 2 * SIZE;
+        spriteC.position.x = spriteA.position.x;
+        spriteA.overlap(groupA, recordPairs);
+        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+
+        // Overlaps none
+        pairs = [];
+        spriteB.position.x = 2 * SIZE;
+        spriteC.position.x = 2 * SIZE;
+        spriteA.overlap(groupA, recordPairs);
+        expect(pairs).to.deep.equal([]);
       });
     });
   });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -1,12 +1,21 @@
+/** @file Tests for collision methods and how they report out.
+ *
+ * There are four 'collision' methods in p5.play:
+ * - overlap (a check with no automatic response)
+ * - displace (the caller pushes the callee out of the way)
+ * - collide (the callee resists the caller, opposite of displace)
+ * - bounce (motion of both callee and caller are affected)
+ */
+// The following jshint options stop it from complaining about chai expectations
+/* jshint -W024 */
+/* jshint expr:true */
+/* global afterEach, beforeEach, describe, expect, it*/
+
 describe('collisions', function() {
-  const SIZE = 10;
-  const HERE = 0;
-  const THERE = SIZE * 2;
+  var SIZE = 10;
   var pInst;
   var spriteA, spriteB, spriteC, spriteD;
   var groupAB, groupCD;
-  var countingCallback;
-
   var callCount, pairs;
 
   function testCallback(a, b) {

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -1,5 +1,7 @@
 describe('collisions', function() {
   const SIZE = 10;
+  const HERE = 0;
+  const THERE = SIZE * 2;
   var pInst;
   var countingCallback;
 
@@ -22,8 +24,8 @@ describe('collisions', function() {
     var argTrackingCallback;
 
     beforeEach(function () {
-      spriteA = pInst.createSprite(0, 0, SIZE, SIZE);
-      spriteB = pInst.createSprite(0, 0, SIZE, SIZE);
+      spriteA = pInst.createSprite(HERE, 0, SIZE, SIZE);
+      spriteB = pInst.createSprite(HERE, 0, SIZE, SIZE);
 
       // Remember last arguments to callback
       argTrackingCallback = function () {
@@ -38,13 +40,13 @@ describe('collisions', function() {
       });
 
       it('returns false if sprites do not overlap', function () {
-        spriteB.position.x += 2 * SIZE;
+        spriteB.position.x = THERE;
         expect(spriteA.overlap(spriteB)).to.be.false;
         expect(spriteB.overlap(spriteA)).to.be.false;
       });
 
       it('sprites overlap when edges just touch', function () {
-        spriteB.position.x += SIZE;
+        spriteB.position.x = SIZE;
         expect(spriteA.overlap(spriteB)).to.be.true;
         expect(spriteB.overlap(spriteA)).to.be.true;
 
@@ -62,7 +64,7 @@ describe('collisions', function() {
       });
 
       it('does not call callback if sprites do not overlap', function () {
-        spriteB.position.x += 2 * SIZE;
+        spriteB.position.x = THERE;
         expect(countingCallback.callCount).to.equal(0);
         spriteA.overlap(spriteB, countingCallback);
         expect(countingCallback.callCount).to.equal(0);
@@ -87,23 +89,17 @@ describe('collisions', function() {
   });
 
   describe('sprite-group', function () {
-    var spriteA, spriteB, spriteC, spriteD;
+    var spriteA, spriteB, spriteC;
     var groupA;
-    var argTrackingCallback;
 
     beforeEach(function () {
-      spriteA = pInst.createSprite(0, 0, SIZE, SIZE);
-      spriteB = pInst.createSprite(0, 0, SIZE, SIZE);
-      spriteC = pInst.createSprite(0, 0, SIZE, SIZE);
+      spriteA = pInst.createSprite(HERE, 0, SIZE, SIZE);
+      spriteB = pInst.createSprite(HERE, 0, SIZE, SIZE);
+      spriteC = pInst.createSprite(HERE, 0, SIZE, SIZE);
 
       groupA = new pInst.Group();
       groupA.add(spriteB);
       groupA.add(spriteC);
-
-      // Remember last arguments to callback
-      argTrackingCallback = function () {
-        argTrackingCallback.lastArgs = arguments;
-      };
     });
 
     describe('overlap', function () {
@@ -112,18 +108,18 @@ describe('collisions', function() {
       });
 
       it('returns true if sprite overlaps first sprite in group', function () {
-        spriteC.position.x += 2 * SIZE;
+        spriteC.position.x = THERE;
         expect(spriteA.overlap(groupA)).to.be.true;
       });
 
       it('returns true if sprite overlaps last sprite in group', function () {
-        spriteB.position.x += 2 * SIZE;
+        spriteB.position.x = THERE;
         expect(spriteA.overlap(groupA)).to.be.true;
       });
 
       it('returns false if sprite does not overlap any sprites in group', function () {
-        spriteB.position.x += 2 * SIZE;
-        spriteC.position.x += 2 * SIZE;
+        spriteB.position.x = THERE;
+        spriteC.position.x = THERE;
         expect(spriteA.overlap(groupA)).to.be.false;
       });
 
@@ -132,7 +128,7 @@ describe('collisions', function() {
       });
 
       it('sprite in group does not overlap self', function () {
-        spriteC.position.x += 2 * SIZE;
+        spriteC.position.x = THERE;
         expect(spriteB.overlap(groupA)).to.be.false;
       });
 
@@ -142,12 +138,12 @@ describe('collisions', function() {
         expect(countingCallback.callCount).to.equal(2);
 
         countingCallback.callCount = 0;
-        spriteB.position.x += 2 * SIZE;
+        spriteB.position.x = THERE;
         spriteA.overlap(groupA, countingCallback);
         expect(countingCallback.callCount).to.equal(1);
 
         countingCallback.callCount = 0;
-        spriteC.position.x += 2 * SIZE;
+        spriteC.position.x = THERE;
         spriteA.overlap(groupA, countingCallback);
         expect(countingCallback.callCount).to.equal(0);
       });
@@ -169,24 +165,135 @@ describe('collisions', function() {
 
         // Overlaps spriteB
         pairs = [];
-        spriteB.position.x = spriteA.position.x;
-        spriteC.position.x = 2 * SIZE;
+        spriteB.position.x = HERE;
+        spriteC.position.x = THERE;
         spriteA.overlap(groupA, recordPairs);
         expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
 
         // Overlaps spriteC
         pairs = [];
-        spriteB.position.x = 2 * SIZE;
-        spriteC.position.x = spriteA.position.x;
+        spriteB.position.x = THERE;
+        spriteC.position.x = HERE;
         spriteA.overlap(groupA, recordPairs);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
 
         // Overlaps none
         pairs = [];
-        spriteB.position.x = 2 * SIZE;
-        spriteC.position.x = 2 * SIZE;
+        spriteB.position.x = THERE;
+        spriteC.position.x = THERE;
         spriteA.overlap(groupA, recordPairs);
         expect(pairs).to.deep.equal([]);
+      });
+    });
+  });
+
+  describe('group-group', function () {
+    var spriteA, spriteB, spriteC, spriteD;
+    var groupA, groupB;
+
+    beforeEach(function () {
+      spriteA = pInst.createSprite(HERE, 0, SIZE, SIZE);
+      spriteB = pInst.createSprite(HERE, 0, SIZE, SIZE);
+      spriteC = pInst.createSprite(HERE, 0, SIZE, SIZE);
+      spriteD = pInst.createSprite(HERE, 0, SIZE, SIZE);
+
+      groupA = new pInst.Group();
+      groupA.add(spriteA);
+      groupA.add(spriteB);
+
+      groupB = new pInst.Group();
+      groupB.add(spriteC);
+      groupB.add(spriteD);
+    });
+
+    describe('overlap', function () {
+      it('returns true if all sprites in group A overlap all sprites in group B', function () {
+        expect(groupA.overlap(groupB)).to.be.true;
+        expect(groupB.overlap(groupA)).to.be.true;
+      });
+
+      it('returns true if any sprites in group A overlap any sprites in group B', function () {
+        // spriteA overlaps spriteC
+        spriteA.position.x = HERE;
+        spriteB.position.x = -THERE;
+        spriteC.position.x = HERE;
+        spriteD.position.x = THERE;
+        expect(groupA.overlap(groupB)).to.be.true;
+        expect(groupB.overlap(groupA)).to.be.true;
+
+        // spriteA overlaps spriteD
+        spriteA.position.x = HERE;
+        spriteB.position.x = -THERE;
+        spriteC.position.x = THERE;
+        spriteD.position.x = HERE;
+        expect(groupA.overlap(groupB)).to.be.true;
+        expect(groupB.overlap(groupA)).to.be.true;
+
+        // spriteB overlaps spriteC
+        spriteA.position.x = -THERE;
+        spriteB.position.x = HERE;
+        spriteC.position.x = HERE;
+        spriteD.position.x = THERE;
+        expect(groupA.overlap(groupB)).to.be.true;
+        expect(groupB.overlap(groupA)).to.be.true;
+
+        // spriteB overlaps spriteD
+        spriteA.position.x = -THERE;
+        spriteB.position.x = HERE;
+        spriteC.position.x = THERE;
+        spriteD.position.x = HERE;
+        expect(groupA.overlap(groupB)).to.be.true;
+        expect(groupB.overlap(groupA)).to.be.true;
+      });
+
+      it('returns false if no sprite in group A overlaps any sprite in group B', function () {
+        spriteC.position.x = THERE;
+        spriteD.position.x = THERE;
+        expect(groupA.overlap(groupB)).to.be.false;
+        expect(groupB.overlap(groupA)).to.be.false;
+      });
+
+      it('group overlaps self if two different sprites within group overlap', function () {
+        expect(groupA.overlap(groupA)).to.be.true;
+      });
+
+      it('group does not overlap self if no sprites within group overlap', function () {
+        spriteB.position.x = THERE;
+        expect(groupA.overlap(groupA)).to.be.false;
+      });
+
+      it('calls callback once for each overlapping sprite pair', function () {
+        // 2 overlap 2
+        expect(countingCallback.callCount).to.equal(0);
+        groupA.overlap(groupB, countingCallback);
+        expect(countingCallback.callCount).to.equal(4);
+
+        // 2 overlap 2 (inverse)
+        countingCallback.callCount = 0;
+        groupB.overlap(groupA, countingCallback);
+        expect(countingCallback.callCount).to.equal(4);
+
+        // 1 overlap 2
+        countingCallback.callCount = 0;
+        spriteB.position.x = -THERE;
+        groupA.overlap(groupB, countingCallback);
+        expect(countingCallback.callCount).to.equal(2);
+
+        // 2 overlap 1
+        countingCallback.callCount = 0;
+        groupB.overlap(groupA, countingCallback);
+        expect(countingCallback.callCount).to.equal(2);
+
+        // 1 overlap 1
+        countingCallback.callCount = 0;
+        spriteC.position.x = THERE;
+        groupA.overlap(groupB, countingCallback);
+        expect(countingCallback.callCount).to.equal(1);
+
+        countingCallback.callCount = 0;
+        spriteC.position.x += 2 * SIZE;
+        spriteA.overlap(groupA, countingCallback);
+        expect(countingCallback.callCount).to.equal(0);
       });
     });
   });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -457,6 +457,55 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('bounce(sprite)', function () {
+      it('false if sprites do not overlap', function () {
+        expect(spriteA.bounce(spriteB)).to.be.false;
+        expect(spriteB.bounce(spriteA)).to.be.false;
+      });
+
+      it('true if sprites overlap', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.bounce(spriteB)).to.be.true;
+
+        moveAToB(spriteA, spriteB);
+        expect(spriteB.bounce(spriteA)).to.be.true;
+      });
+
+      it('calls callback once if sprites overlap', function () {
+        expect(callCount).to.equal(0);
+
+        moveAToB(spriteA, spriteB);
+        spriteA.bounce(spriteB, testCallback);
+        expect(callCount).to.equal(1);
+
+        moveAToB(spriteA, spriteB);
+        spriteB.bounce(spriteA, testCallback);
+        expect(callCount).to.equal(2);
+      });
+
+      it('does not call callback if sprites do not overlap', function () {
+        expect(callCount).to.equal(0);
+        spriteA.bounce(spriteB, testCallback);
+        expect(callCount).to.equal(0);
+        spriteB.bounce(spriteA, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback', function () {
+        it('A-B', function () {
+          moveAToB(spriteA, spriteB);
+          spriteA.bounce(spriteB, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+        });
+
+        it('B-A', function () {
+          moveAToB(spriteA, spriteB);
+          spriteB.bounce(spriteA, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
+        });
+      });
+    });
   });
 
   describe('group', function () {

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -506,6 +506,91 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('bounce(group)', function () {
+      it('false if sprite does not overlap any sprites in group', function () {
+        expect(spriteA.bounce(groupCD)).to.be.false;
+      });
+
+      it('does not check against sprites not in target group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.bounce(groupCD)).to.be.false;
+      });
+
+      it('does not care if sprites in target group overlap each other', function () {
+        moveAToB(spriteC, spriteD);
+        expect(spriteA.bounce(groupCD)).to.be.false;
+      });
+
+      it('true if sprite overlaps first sprite in group', function () {
+        moveAToB(spriteA, spriteC);
+        expect(spriteA.bounce(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps last sprite in group', function () {
+        moveAToB(spriteA, spriteD);
+        expect(spriteA.bounce(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps every sprite in group', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expect(spriteA.bounce(groupCD)).to.be.true;
+      });
+
+      it('does not overlap self when checking own group', function () {
+        expect(spriteA.bounce(groupAB)).to.be.false;
+      });
+
+      it('can overlap with other sprites in own group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.bounce(groupAB)).to.be.true;
+      });
+
+      it('does not call callback when not overlapping any sprites', function () {
+        spriteA.bounce(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      it('calls callback once when overlapping one sprite', function () {
+        moveAToB(spriteC, spriteA);
+        spriteA.bounce(groupCD, testCallback);
+        expect(callCount).to.equal(1);
+      });
+
+      it('calls callback twice when overlapping two sprites', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.bounce(groupCD, testCallback);
+        expect(callCount).to.equal(1);
+        // Note: The first collision (A-C) displaces A, so the second collision
+        // (A-D) doesn't happen.
+      });
+
+      describe('passes collider and collidee to callback', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          spriteA.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          spriteA.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
+
+        it('A-C-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          spriteA.bounce(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name]]);
+          // Note: The first collision (A-C) displaces A, so the second collision
+          // (A-D) doesn't happen.
+        });
+      });
+    });
   });
 
   describe('group', function () {

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -323,6 +323,55 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('collide(sprite)', function () {
+      it('false if sprites do not overlap', function () {
+        expect(spriteA.collide(spriteB)).to.be.false;
+        expect(spriteB.collide(spriteA)).to.be.false;
+      });
+
+      it('true if sprites overlap', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.collide(spriteB)).to.be.true;
+
+        moveAToB(spriteA, spriteB);
+        expect(spriteB.collide(spriteA)).to.be.true;
+      });
+
+      it('calls callback once if sprites overlap', function () {
+        expect(callCount).to.equal(0);
+
+        moveAToB(spriteA, spriteB);
+        spriteA.collide(spriteB, testCallback);
+        expect(callCount).to.equal(1);
+
+        moveAToB(spriteA, spriteB);
+        spriteB.collide(spriteA, testCallback);
+        expect(callCount).to.equal(2);
+      });
+
+      it('does not call callback if sprites do not overlap', function () {
+        expect(callCount).to.equal(0);
+        spriteA.collide(spriteB, testCallback);
+        expect(callCount).to.equal(0);
+        spriteB.collide(spriteA, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback', function () {
+        it('A-B', function () {
+          moveAToB(spriteA, spriteB);
+          spriteA.collide(spriteB, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+        });
+
+        it('B-A', function () {
+          moveAToB(spriteA, spriteB);
+          spriteB.collide(spriteA, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
+        });
+      });
+    });
   });
 
   describe('group', function () {

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -1210,5 +1210,62 @@ describe('collisions', function() {
         });
       });
     });
+
+    describe('bounce(sprite)', function () {
+      it('false if no sprites overlap', function () {
+        expect(groupAB.bounce(spriteC)).to.be.false;
+      });
+
+      it('false if no sprite in group overlaps target sprite', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.bounce(spriteC)).to.be.false;
+      });
+
+      it('true if all sprites in group overlap target sprite', function () {
+        moveAToB(spriteA, spriteC);
+        moveAToB(spriteB, spriteC);
+        expect(groupAB.bounce(spriteC)).to.be.true;
+      });
+
+      describe('true if any sprites in group overlap target sprite', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expect(groupAB.bounce(spriteC)).to.be.true;
+        });
+
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expect(groupAB.bounce(spriteC)).to.be.true;
+        });
+      });
+
+      it('does not call callback when not overlapping sprite', function () {
+        groupAB.bounce(spriteC, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      describe('passes collider and collidee to callback for each overlap', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.bounce(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.bounce(spriteC, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C', function () {
+          moveAToB(spriteA, spriteC);
+          moveAToB(spriteB, spriteC);
+          groupAB.bounce(spriteC, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+        });
+      });
+    });
   });
 });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -3,367 +3,338 @@ describe('collisions', function() {
   const HERE = 0;
   const THERE = SIZE * 2;
   var pInst;
+  var spriteA, spriteB, spriteC, spriteD;
+  var groupAB, groupCD;
   var countingCallback;
+
+  var callCount, pairs;
+
+  function testCallback(a, b) {
+    callCount++;
+    pairs.push([a.name, b.name]);
+  }
+
+  function moveAToB(a, b) {
+    a.position.x = b.position.x;
+  }
 
   beforeEach(function () {
     pInst = new p5(function() {});
+    callCount = 0;
+    pairs = [];
 
-    // Count callback calls
-    countingCallback = function () {
-      countingCallback.callCount++;
-    };
-    countingCallback.callCount = 0;
+    function createTestSprite(letter, position) {
+      var sprite = pInst.createSprite(position, 0, SIZE, SIZE);
+      sprite.name = 'sprite' + letter;
+      return sprite;
+    }
+
+    spriteA = createTestSprite('A', 2 * SIZE);
+    spriteB = createTestSprite('B', 4 * SIZE);
+    spriteC = createTestSprite('C', 6 * SIZE);
+    spriteD = createTestSprite('D', 8 * SIZE);
+    groupAB = new pInst.Group();
+    groupAB.add(spriteA);
+    groupAB.add(spriteB);
+    groupCD = new pInst.Group();
+    groupCD.add(spriteC);
+    groupCD.add(spriteD);
+
+    // Assert initial test state:
+    // - Four sprites in two groups
+    // - no two sprites overlap
+    expect(pInst.allSprites.length).to.equal(4);
+    expect(groupAB.length).to.equal(2);
+    expect(groupCD.length).to.equal(2);
+    pInst.allSprites.forEach(function (caller) {
+      pInst.allSprites.forEach(function (callee) {
+        expect(caller.overlap(callee)).to.be.false;
+      });
+    });
   });
 
   afterEach(function () {
     pInst.remove();
   });
 
-  describe('sprite-sprite', function () {
-    var spriteA, spriteB;
-    var argTrackingCallback;
-
-    beforeEach(function () {
-      spriteA = pInst.createSprite(HERE, 0, SIZE, SIZE);
-      spriteB = pInst.createSprite(HERE, 0, SIZE, SIZE);
-
-      // Remember last arguments to callback
-      argTrackingCallback = function () {
-        argTrackingCallback.lastArgs = arguments;
-      };
-    });
-
-    describe('overlap', function () {
-      it('returns true if sprites overlap', function () {
-        expect(spriteA.overlap(spriteB)).to.be.true;
-        expect(spriteB.overlap(spriteA)).to.be.true;
-      });
-
-      it('returns false if sprites do not overlap', function () {
-        spriteB.position.x = THERE;
+  describe('sprite', function () {
+    describe('overlap(sprite)', function () {
+      it('false if sprites do not overlap', function () {
         expect(spriteA.overlap(spriteB)).to.be.false;
         expect(spriteB.overlap(spriteA)).to.be.false;
       });
 
-      it('sprites overlap when edges just touch', function () {
-        spriteB.position.x = SIZE;
+      it('true if sprites overlap', function () {
+        moveAToB(spriteA, spriteB);
         expect(spriteA.overlap(spriteB)).to.be.true;
         expect(spriteB.overlap(spriteA)).to.be.true;
-
-        spriteB.position.x += 0.0001;
-        expect(spriteA.overlap(spriteB)).to.be.false;
-        expect(spriteB.overlap(spriteA)).to.be.false;
       });
 
       it('calls callback once if sprites overlap', function () {
-        expect(countingCallback.callCount).to.equal(0);
-        spriteA.overlap(spriteB, countingCallback);
-        expect(countingCallback.callCount).to.equal(1);
-        spriteB.overlap(spriteA, countingCallback);
-        expect(countingCallback.callCount).to.equal(2);
+        moveAToB(spriteA, spriteB);
+        expect(callCount).to.equal(0);
+        spriteA.overlap(spriteB, testCallback);
+        expect(callCount).to.equal(1);
+        spriteB.overlap(spriteA, testCallback);
+        expect(callCount).to.equal(2);
       });
 
       it('does not call callback if sprites do not overlap', function () {
-        spriteB.position.x = THERE;
-        expect(countingCallback.callCount).to.equal(0);
-        spriteA.overlap(spriteB, countingCallback);
-        expect(countingCallback.callCount).to.equal(0);
-        spriteB.overlap(spriteA, countingCallback);
-        expect(countingCallback.callCount).to.equal(0);
+        expect(callCount).to.equal(0);
+        spriteA.overlap(spriteB, testCallback);
+        expect(callCount).to.equal(0);
+        spriteB.overlap(spriteA, testCallback);
+        expect(callCount).to.equal(0);
       });
 
-      it('passes collider and collidee to callback', function () {
-        spriteA.overlap(spriteB, argTrackingCallback);
-        expect(argTrackingCallback.lastArgs).to.be.arguments;
-        expect(argTrackingCallback.lastArgs.length).to.be.at.least(2);
-        expect(argTrackingCallback.lastArgs[0]).to.equal(spriteA);
-        expect(argTrackingCallback.lastArgs[1]).to.equal(spriteB);
+      describe('passes collider and collidee to callback', function () {
+        it('A-B', function () {
+          moveAToB(spriteA, spriteB);
+          spriteA.overlap(spriteB, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
+        });
 
-        spriteB.overlap(spriteA, argTrackingCallback);
-        expect(argTrackingCallback.lastArgs).to.be.arguments;
-        expect(argTrackingCallback.lastArgs.length).to.be.at.least(2);
-        expect(argTrackingCallback.lastArgs[0]).to.equal(spriteB);
-        expect(argTrackingCallback.lastArgs[1]).to.equal(spriteA);
+        it('B-A', function () {
+          moveAToB(spriteA, spriteB);
+          spriteB.overlap(spriteA, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
+        });
+      });
+    });
+
+    describe('overlap(group)', function () {
+      it('false if sprite does not overlap any sprites in group', function () {
+        expect(spriteA.overlap(groupCD)).to.be.false;
+      });
+
+      it('does not check against sprites not in target group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.overlap(groupCD)).to.be.false;
+      });
+
+      it('does not care if sprites in target group overlap each other', function () {
+        moveAToB(spriteC, spriteD);
+        expect(spriteA.overlap(groupCD)).to.be.false;
+      });
+
+      it('true if sprite overlaps first sprite in group', function () {
+        moveAToB(spriteA, spriteC);
+        expect(spriteA.overlap(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps last sprite in group', function () {
+        moveAToB(spriteA, spriteD);
+        expect(spriteA.overlap(groupCD)).to.be.true;
+      });
+
+      it('true if sprite overlaps every sprite in group', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expect(spriteA.overlap(groupCD)).to.be.true;
+      });
+
+      it('does not overlap self when checking own group', function () {
+        expect(spriteA.overlap(groupAB)).to.be.false;
+      });
+
+      it('can overlap with other sprites in own group', function () {
+        moveAToB(spriteA, spriteB);
+        expect(spriteA.overlap(groupAB)).to.be.true;
+      });
+
+      it('does not call callback when not overlapping any sprites', function () {
+        spriteA.overlap(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
+
+      it('calls callback once when overlapping one sprite', function () {
+        moveAToB(spriteC, spriteA);
+        spriteA.overlap(groupCD, testCallback);
+        expect(callCount).to.equal(1);
+      });
+
+      it('calls callback twice when overlapping two sprites', function () {
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        spriteA.overlap(groupCD, testCallback);
+        expect(callCount).to.equal(2);
+      });
+
+      describe('passes collider and collidee to callback', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          spriteA.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
+
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          spriteA.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
+
+        it('A-C, A-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          spriteA.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteA.name, spriteD.name]]);
+        });
       });
     });
   });
 
-  describe('sprite-group', function () {
-    var spriteA, spriteB, spriteC;
-    var groupA;
+  describe('group', function () {
+    describe('overlap(group)', function () {
+      function expectGroupsOverlap(outcome) {
+        expect(groupAB.overlap(groupCD)).to.equal(outcome);
+        expect(groupCD.overlap(groupAB)).to.equal(outcome);
+      }
 
-    beforeEach(function () {
-      spriteA = pInst.createSprite(HERE, 0, SIZE, SIZE);
-      spriteB = pInst.createSprite(HERE, 0, SIZE, SIZE);
-      spriteC = pInst.createSprite(HERE, 0, SIZE, SIZE);
-
-      groupA = new pInst.Group();
-      groupA.add(spriteB);
-      groupA.add(spriteC);
-    });
-
-    describe('overlap', function () {
-      it('returns true if sprite overlaps every sprite in group', function () {
-        expect(spriteA.overlap(groupA)).to.be.true;
+      it('false if no sprites overlap', function () {
+        expectGroupsOverlap(false);
       });
 
-      it('returns true if sprite overlaps first sprite in group', function () {
-        spriteC.position.x = THERE;
-        expect(spriteA.overlap(groupA)).to.be.true;
+      it('false if no sprite in group A overlaps any sprite in group B', function () {
+        moveAToB(spriteA, spriteB);
+        moveAToB(spriteC, spriteD);
+        expectGroupsOverlap(false);
       });
 
-      it('returns true if sprite overlaps last sprite in group', function () {
-        spriteB.position.x = THERE;
-        expect(spriteA.overlap(groupA)).to.be.true;
+      it('true if all sprites in group A overlap all sprites in group B', function () {
+        moveAToB(spriteB, spriteA);
+        moveAToB(spriteC, spriteA);
+        moveAToB(spriteD, spriteA);
+        expectGroupsOverlap(true);
       });
 
-      it('returns false if sprite does not overlap any sprites in group', function () {
-        spriteB.position.x = THERE;
-        spriteC.position.x = THERE;
-        expect(spriteA.overlap(groupA)).to.be.false;
-      });
+      describe('true if any sprites in group A overlap any sprites in group B', function () {
+        it('A overlaps C', function () {
+          moveAToB(spriteA, spriteC);
+          expectGroupsOverlap(true);
+        });
 
-      it('sprite in group can overlap with other sprites in group', function () {
-        expect(spriteB.overlap(groupA)).to.be.true;
-      });
+        it('A overlaps D', function () {
+          moveAToB(spriteA, spriteD);
+          expectGroupsOverlap(true);
+        });
 
-      it('sprite in group does not overlap self', function () {
-        spriteC.position.x = THERE;
-        expect(spriteB.overlap(groupA)).to.be.false;
-      });
+        it('B overlaps C', function () {
+          moveAToB(spriteB, spriteC);
+          expectGroupsOverlap(true);
+        });
 
-      it('calls callback once for each overlapping sprite', function () {
-        expect(countingCallback.callCount).to.equal(0);
-        spriteA.overlap(groupA, countingCallback);
-        expect(countingCallback.callCount).to.equal(2);
-
-        countingCallback.callCount = 0;
-        spriteB.position.x = THERE;
-        spriteA.overlap(groupA, countingCallback);
-        expect(countingCallback.callCount).to.equal(1);
-
-        countingCallback.callCount = 0;
-        spriteC.position.x = THERE;
-        spriteA.overlap(groupA, countingCallback);
-        expect(countingCallback.callCount).to.equal(0);
-      });
-
-      it('passes collider and collidee to callback', function () {
-        spriteA.name = 'spriteA';
-        spriteB.name = 'spriteB';
-        spriteC.name = 'spriteC';
-
-        var pairs;
-        function recordPairs(a, b) {
-          pairs.push([a.name, b.name]);
-        }
-
-        // Overlaps both
-        pairs = [];
-        spriteA.overlap(groupA, recordPairs);
-        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name], [spriteA.name, spriteC.name]]);
-
-        // Overlaps spriteB
-        pairs = [];
-        spriteB.position.x = HERE;
-        spriteC.position.x = THERE;
-        spriteA.overlap(groupA, recordPairs);
-        expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
-
-        // Overlaps spriteC
-        pairs = [];
-        spriteB.position.x = THERE;
-        spriteC.position.x = HERE;
-        spriteA.overlap(groupA, recordPairs);
-        expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
-
-        // Overlaps none
-        pairs = [];
-        spriteB.position.x = THERE;
-        spriteC.position.x = THERE;
-        spriteA.overlap(groupA, recordPairs);
-        expect(pairs).to.deep.equal([]);
-      });
-    });
-  });
-
-  describe('group-group', function () {
-    var spriteA, spriteB, spriteC, spriteD;
-    var groupA, groupB;
-
-    beforeEach(function () {
-      spriteA = pInst.createSprite(HERE, 0, SIZE, SIZE);
-      spriteB = pInst.createSprite(HERE, 0, SIZE, SIZE);
-      spriteC = pInst.createSprite(HERE, 0, SIZE, SIZE);
-      spriteD = pInst.createSprite(HERE, 0, SIZE, SIZE);
-
-      groupA = new pInst.Group();
-      groupA.add(spriteA);
-      groupA.add(spriteB);
-
-      groupB = new pInst.Group();
-      groupB.add(spriteC);
-      groupB.add(spriteD);
-    });
-
-    describe('overlap', function () {
-      it('returns true if all sprites in group A overlap all sprites in group B', function () {
-        expect(groupA.overlap(groupB)).to.be.true;
-        expect(groupB.overlap(groupA)).to.be.true;
-      });
-
-      it('returns true if any sprites in group A overlap any sprites in group B', function () {
-        // spriteA overlaps spriteC
-        spriteA.position.x = HERE;
-        spriteB.position.x = -THERE;
-        spriteC.position.x = HERE;
-        spriteD.position.x = THERE;
-        expect(groupA.overlap(groupB)).to.be.true;
-        expect(groupB.overlap(groupA)).to.be.true;
-
-        // spriteA overlaps spriteD
-        spriteA.position.x = HERE;
-        spriteB.position.x = -THERE;
-        spriteC.position.x = THERE;
-        spriteD.position.x = HERE;
-        expect(groupA.overlap(groupB)).to.be.true;
-        expect(groupB.overlap(groupA)).to.be.true;
-
-        // spriteB overlaps spriteC
-        spriteA.position.x = -THERE;
-        spriteB.position.x = HERE;
-        spriteC.position.x = HERE;
-        spriteD.position.x = THERE;
-        expect(groupA.overlap(groupB)).to.be.true;
-        expect(groupB.overlap(groupA)).to.be.true;
-
-        // spriteB overlaps spriteD
-        spriteA.position.x = -THERE;
-        spriteB.position.x = HERE;
-        spriteC.position.x = THERE;
-        spriteD.position.x = HERE;
-        expect(groupA.overlap(groupB)).to.be.true;
-        expect(groupB.overlap(groupA)).to.be.true;
-      });
-
-      it('returns false if no sprite in group A overlaps any sprite in group B', function () {
-        spriteC.position.x = THERE;
-        spriteD.position.x = THERE;
-        expect(groupA.overlap(groupB)).to.be.false;
-        expect(groupB.overlap(groupA)).to.be.false;
-      });
-
-      it('group overlaps self if two different sprites within group overlap', function () {
-        expect(groupA.overlap(groupA)).to.be.true;
+        it('B overlaps D', function () {
+          moveAToB(spriteB, spriteD);
+          expectGroupsOverlap(true);
+        });
       });
 
       it('group does not overlap self if no sprites within group overlap', function () {
-        spriteB.position.x = THERE;
-        expect(groupA.overlap(groupA)).to.be.false;
+        expect(groupAB.overlap(groupAB)).to.be.false;
       });
 
-      it('calls callback once for each overlapping sprite pair', function () {
-        // 2 overlap 2
-        expect(countingCallback.callCount).to.equal(0);
-        groupA.overlap(groupB, countingCallback);
-        expect(countingCallback.callCount).to.equal(4);
-
-        // 2 overlap 2 (inverse)
-        countingCallback.callCount = 0;
-        groupB.overlap(groupA, countingCallback);
-        expect(countingCallback.callCount).to.equal(4);
-
-        // 1 overlap 2
-        countingCallback.callCount = 0;
-        spriteB.position.x = -THERE;
-        groupA.overlap(groupB, countingCallback);
-        expect(countingCallback.callCount).to.equal(2);
-
-        // 2 overlap 1
-        countingCallback.callCount = 0;
-        groupB.overlap(groupA, countingCallback);
-        expect(countingCallback.callCount).to.equal(2);
-
-        // 1 overlap 1
-        countingCallback.callCount = 0;
-        spriteC.position.x = THERE;
-        groupA.overlap(groupB, countingCallback);
-        expect(countingCallback.callCount).to.equal(1);
-
-        // None overlap
-        countingCallback.callCount = 0;
-        spriteD.position.x = THERE;
-        groupA.overlap(groupB, countingCallback);
-        expect(countingCallback.callCount).to.equal(0);
+      it('group overlaps self if two different sprites within group overlap', function () {
+        moveAToB(spriteA, spriteB);
+        expect(groupAB.overlap(groupAB)).to.be.true;
       });
 
-      it('passes collider and collidee to callback', function () {
-        spriteA.name = 'spriteA';
-        spriteB.name = 'spriteB';
-        spriteC.name = 'spriteC';
-        spriteD.name = 'spriteD';
+      it('does not call callback when not overlapping any sprites', function () {
+        groupAB.overlap(groupCD, testCallback);
+        expect(callCount).to.equal(0);
+      });
 
-        var pairs;
-        function recordPairs(a, b) {
-          pairs.push([a.name, b.name]);
-        }
+      describe('passes collider and collidee to callback for each pair', function () {
+        it('A-C', function () {
+          moveAToB(spriteA, spriteC);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
+        });
 
-        // 2 overlap 2
-        pairs = [];
-        groupA.overlap(groupB, recordPairs);
-        expect(pairs).to.deep.equal([
-          [spriteA.name, spriteC.name],
-          [spriteA.name, spriteD.name],
-          [spriteB.name, spriteC.name],
-          [spriteB.name, spriteD.name]]);
+        it('A-D', function () {
+          moveAToB(spriteA, spriteD);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
+        });
 
-        // 2 overlap 2 (inverse)
-        pairs = [];
-        groupB.overlap(groupA, recordPairs);
-        expect(pairs).to.deep.equal([
-          [spriteC.name, spriteA.name],
-          [spriteC.name, spriteB.name],
-          [spriteD.name, spriteA.name],
-          [spriteD.name, spriteB.name]]);
+        it('B-C', function () {
+          moveAToB(spriteB, spriteC);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
+        });
 
-        // 1 overlap 2
-        spriteB.position.x = -THERE;
-        pairs = [];
-        groupA.overlap(groupB, recordPairs);
-        expect(pairs).to.deep.equal([
-          [spriteA.name, spriteC.name],
-          [spriteA.name, spriteD.name]]);
+        it('B-D', function () {
+          moveAToB(spriteB, spriteD);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
+        });
 
-        // 2 overlap 1
-        pairs = [];
-        groupB.overlap(groupA, recordPairs);
-        expect(pairs).to.deep.equal([
-          [spriteC.name, spriteA.name],
-          [spriteD.name, spriteA.name]]);
+        it('A-B-C', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteC.name]]);
+        });
 
-        // 1 overlap 1
-        spriteC.position.x = THERE;
-        pairs = [];
-        groupA.overlap(groupB, recordPairs);
-        expect(pairs).to.deep.equal([
-          [spriteA.name, spriteD.name]]);
+        it('A-B-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteD.name]]);
+        });
 
-        // 1 overlap 1, twice
-        spriteB.position.x = THERE;
-        pairs = [];
-        groupA.overlap(groupB, recordPairs);
-        expect(pairs).to.deep.equal([
-          [spriteA.name, spriteD.name],
-          [spriteB.name, spriteC.name]]);
+        it('A-C-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteA.name, spriteD.name]]);
+        });
 
-        // none overlap
-        spriteA.position.x = HERE;
-        spriteB.position.x = HERE;
-        spriteC.position.x = THERE;
-        spriteD.position.x = THERE;
-        pairs = [];
-        groupA.overlap(groupB, recordPairs);
-        expect(pairs).to.be.empty;
+        it('B-C-D', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteB);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteB.name, spriteC.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-C, B-D', function () {
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteB);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteB.name, spriteD.name]]);
+        });
+
+        it('A-D, B-C', function () {
+          moveAToB(spriteC, spriteB);
+          moveAToB(spriteD, spriteA);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteC.name]]);
+        });
+
+        it('A-B-C-D', function () {
+          moveAToB(spriteB, spriteA);
+          moveAToB(spriteC, spriteA);
+          moveAToB(spriteD, spriteA);
+          groupAB.overlap(groupCD, testCallback);
+          expect(pairs).to.deep.equal([
+            [spriteA.name, spriteC.name],
+            [spriteA.name, spriteD.name],
+            [spriteB.name, spriteC.name],
+            [spriteB.name, spriteD.name]]);
+        });
       });
     });
   });

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -290,10 +290,80 @@ describe('collisions', function() {
         groupA.overlap(groupB, countingCallback);
         expect(countingCallback.callCount).to.equal(1);
 
+        // None overlap
         countingCallback.callCount = 0;
-        spriteC.position.x += 2 * SIZE;
-        spriteA.overlap(groupA, countingCallback);
+        spriteD.position.x = THERE;
+        groupA.overlap(groupB, countingCallback);
         expect(countingCallback.callCount).to.equal(0);
+      });
+
+      it('passes collider and collidee to callback', function () {
+        spriteA.name = 'spriteA';
+        spriteB.name = 'spriteB';
+        spriteC.name = 'spriteC';
+        spriteD.name = 'spriteD';
+
+        var pairs;
+        function recordPairs(a, b) {
+          pairs.push([a.name, b.name]);
+        }
+
+        // 2 overlap 2
+        pairs = [];
+        groupA.overlap(groupB, recordPairs);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteC.name],
+          [spriteB.name, spriteD.name]]);
+
+        // 2 overlap 2 (inverse)
+        pairs = [];
+        groupB.overlap(groupA, recordPairs);
+        expect(pairs).to.deep.equal([
+          [spriteC.name, spriteA.name],
+          [spriteC.name, spriteB.name],
+          [spriteD.name, spriteA.name],
+          [spriteD.name, spriteB.name]]);
+
+        // 1 overlap 2
+        spriteB.position.x = -THERE;
+        pairs = [];
+        groupA.overlap(groupB, recordPairs);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteC.name],
+          [spriteA.name, spriteD.name]]);
+
+        // 2 overlap 1
+        pairs = [];
+        groupB.overlap(groupA, recordPairs);
+        expect(pairs).to.deep.equal([
+          [spriteC.name, spriteA.name],
+          [spriteD.name, spriteA.name]]);
+
+        // 1 overlap 1
+        spriteC.position.x = THERE;
+        pairs = [];
+        groupA.overlap(groupB, recordPairs);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name]]);
+
+        // 1 overlap 1, twice
+        spriteB.position.x = THERE;
+        pairs = [];
+        groupA.overlap(groupB, recordPairs);
+        expect(pairs).to.deep.equal([
+          [spriteA.name, spriteD.name],
+          [spriteB.name, spriteC.name]]);
+
+        // none overlap
+        spriteA.position.x = HERE;
+        spriteB.position.x = HERE;
+        spriteC.position.x = THERE;
+        spriteD.position.x = THERE;
+        pairs = [];
+        groupA.overlap(groupB, recordPairs);
+        expect(pairs).to.be.empty;
       });
     });
   });


### PR DESCRIPTION
The four collision methods in p5.play (`overlap`, `collide`, `displace` and `bounce`) had some common problems where their return values did not behave as documented when groups are involved.  I've fixed those return value problems and written fairly comprehensive test coverage of how these methods report collision when it occurs.

My tests do _not_ cover the behavior of different collider types, whether overlap is calculated correctly, or the changes to sprite position/velocity that can occur as a result of collisions (for example, I have not fixed #9 yet).  I'm only concerned here with boolean return values, and whether callbacks are called the appropriate number of times with the appropriate arguments.

# The bugs
Sprite-sprite checks seem to work as expected.

* `sprite.collide(group)`, `sprite.displace(group)` and `sprite.bounce(group)` had a problem where they would return the value of the _last_ check they did against the group, where the expected behavior is to return true if _any_ collision occurred.  `sprite.overlap(group)` did not have this problem, because it's a separate case inside the `AABBops` method.
* `group.overlap(sprite)` (and each variant) was documented to return a boolean for whether an overlap occurred, but its implementation always returned `undefined`.
* `group.overlap(group)` exhibited both of the above problems.

# The tests
The test suite is long and has quite a bit of copy-paste to cover the four similar collision methods in all four caller-callee configurations: sprite(sprite), sprite(group), group(sprite) and group(group).  I went ahead and kept much of the duplication because there _are_ some subtle differences between tests for the different methods - for example, when all sprites start in the same position, sprite.collide(group) will result in only one callback, since the first collision displaces the caller, but sprite.displace(group) will result in many callbacks as the caller displaces each group member in turn.

When reading the tests, the general setup is this:

* There are four sprites, A through D.  They all start in different positions.
* There are two groups, AB and CD, named for the sprites they contain.
* If sprites should overlap for a test they will always be explicitly positioned prior to the test by calling `moveAToB()`.

Here's the complete successful test run (from collisions.js, only):
```
  collisions
    sprite.overlap(sprite)
      ✓ false if sprites do not overlap 
      ✓ true if sprites overlap 
      ✓ calls callback once if sprites overlap 
      ✓ does not call callback if sprites do not overlap 
      passes collider and collidee to callback
        ✓ A-B 
        ✓ B-A 
    sprite.overlap(group)
      ✓ false if sprite does not overlap any sprites in group 
      ✓ does not check against sprites not in target group 
      ✓ does not care if sprites in target group overlap each other 
      ✓ true if sprite overlaps first sprite in group 
      ✓ true if sprite overlaps last sprite in group 
      ✓ true if sprite overlaps every sprite in group 
      ✓ does not overlap self when checking own group 
      ✓ can overlap with other sprites in own group 
      ✓ does not call callback when not overlapping any sprites 
      ✓ calls callback once when overlapping one sprite 
      ✓ calls callback twice when overlapping two sprites 
      passes collider and collidee to callback
        ✓ A-C 
        ✓ A-D 
        ✓ A-C-D 
    sprite.displace(sprite)
      ✓ false if sprites do not overlap 
      ✓ true if sprites overlap 
      ✓ calls callback once if sprites overlap 
      ✓ does not call callback if sprites do not overlap 
      passes collider and collidee to callback
        ✓ A-B 
        ✓ B-A 
    sprite.displace(group)
      ✓ false if sprite does not overlap any sprites in group 
      ✓ does not check against sprites not in target group 
      ✓ does not care if sprites in target group overlap each other 
      ✓ true if sprite overlaps first sprite in group 
      ✓ true if sprite overlaps last sprite in group 
      ✓ true if sprite overlaps every sprite in group 
      ✓ does not overlap self when checking own group 
      ✓ can overlap with other sprites in own group 
      ✓ does not call callback when not overlapping any sprites 
      ✓ calls callback once when overlapping one sprite 
      ✓ calls callback twice when overlapping two sprites 
      passes collider and collidee to callback
        ✓ A-C 
        ✓ A-D 
        ✓ A-C-D 
    sprite.collide(sprite)
      ✓ false if sprites do not overlap 
      ✓ true if sprites overlap 
      ✓ calls callback once if sprites overlap 
      ✓ does not call callback if sprites do not overlap 
      passes collider and collidee to callback
        ✓ A-B 
        ✓ B-A 
    sprite.collide(group)
      ✓ false if sprite does not overlap any sprites in group 
      ✓ does not check against sprites not in target group 
      ✓ does not care if sprites in target group overlap each other 
      ✓ true if sprite overlaps first sprite in group 
      ✓ true if sprite overlaps last sprite in group 
      ✓ true if sprite overlaps every sprite in group 
      ✓ does not overlap self when checking own group 
      ✓ can overlap with other sprites in own group 
      ✓ does not call callback when not overlapping any sprites 
      ✓ calls callback once when overlapping one sprite 
      ✓ calls callback twice when overlapping two sprites 
      passes collider and collidee to callback
        ✓ A-C 
        ✓ A-D 
        ✓ A-C-D 
    sprite.bounce(sprite)
      ✓ false if sprites do not overlap 
      ✓ true if sprites overlap 
      ✓ calls callback once if sprites overlap 
      ✓ does not call callback if sprites do not overlap 
      passes collider and collidee to callback
        ✓ A-B 
        ✓ B-A 
    sprite.bounce(group)
      ✓ false if sprite does not overlap any sprites in group 
      ✓ does not check against sprites not in target group 
      ✓ does not care if sprites in target group overlap each other 
      ✓ true if sprite overlaps first sprite in group 
      ✓ true if sprite overlaps last sprite in group 
      ✓ true if sprite overlaps every sprite in group 
      ✓ does not overlap self when checking own group 
      ✓ can overlap with other sprites in own group 
      ✓ does not call callback when not overlapping any sprites 
      ✓ calls callback once when overlapping one sprite 
      ✓ calls callback twice when overlapping two sprites 
      passes collider and collidee to callback
        ✓ A-C 
        ✓ A-D 
        ✓ A-C-D 
    group.overlap(sprite)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group overlaps target sprite 
      ✓ true if all sprites in group overlap target sprite 
      ✓ does not call callback when not overlapping sprite 
      true if any sprites in group overlap target sprite
        ✓ A overlaps C 
        ✓ B overlaps C 
      passes collider and collidee to callback for each overlap
        ✓ A-C 
        ✓ B-C 
        ✓ A-B-C 
    group.overlap(group)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group AB overlaps any sprite in group CD 
      ✓ true if all sprites in group AB overlap all sprites in group CD 
      ✓ group does not overlap self if no sprites within group overlap 
      ✓ group overlaps self if two different sprites within group overlap 
      ✓ does not call callback when not overlapping any sprites 
      true if any sprites in group AB overlap any sprites in group CD
        ✓ A overlaps C 
        ✓ A overlaps D 
        ✓ B overlaps C 
        ✓ B overlaps D 
      passes collider and collidee to callback for each pair
        ✓ A-C 
        ✓ A-D 
        ✓ B-C 
        ✓ B-D 
        ✓ A-B-C 
        ✓ A-B-D 
        ✓ A-C-D 
        ✓ B-C-D 
        ✓ A-C, B-D 
        ✓ A-D, B-C 
        ✓ A-B-C-D 
    group.displace(sprite)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group overlaps target sprite 
      ✓ true if all sprites in group overlap target sprite 
      ✓ does not call callback when not overlapping sprite 
      true if any sprites in group overlap target sprite
        ✓ A overlaps C 
        ✓ B overlaps C 
      passes collider and collidee to callback for each overlap
        ✓ A-C 
        ✓ B-C 
        ✓ A-B-C 
    group.displace(group)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group AB overlaps any sprite in group CD 
      ✓ true if all sprites in group AB overlap all sprites in group CD 
      ✓ group does not overlap self if no sprites within group overlap 
      ✓ group overlaps self if two different sprites within group overlap 
      ✓ does not call callback when not overlapping any sprites 
      true if any sprites in group AB overlap any sprites in group CD
        ✓ A overlaps C 
        ✓ A overlaps D 
        ✓ B overlaps C 
        ✓ B overlaps D 
      passes collider and collidee to callback for each pair
        ✓ A-C 
        ✓ A-D 
        ✓ B-C 
        ✓ B-D 
        ✓ A-B-C 
        ✓ A-B-D 
        ✓ A-C-D 
        ✓ B-C-D 
        ✓ A-C, B-D 
        ✓ A-D, B-C 
        ✓ A-B-C-D 
    group.collide(sprite)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group overlaps target sprite 
      ✓ true if all sprites in group overlap target sprite 
      ✓ does not call callback when not overlapping sprite 
      true if any sprites in group overlap target sprite
        ✓ A overlaps C 
        ✓ B overlaps C 
      passes collider and collidee to callback for each overlap
        ✓ A-C 
        ✓ B-C 
        ✓ A-B-C 
    group.collide(group)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group AB overlaps any sprite in group CD 
      ✓ true if all sprites in group AB overlap all sprites in group CD 
      ✓ group does not overlap self if no sprites within group overlap 
      ✓ group overlaps self if two different sprites within group overlap 
      ✓ does not call callback when not overlapping any sprites 
      true if any sprites in group AB overlap any sprites in group CD
        ✓ A overlaps C 
        ✓ A overlaps D 
        ✓ B overlaps C 
        ✓ B overlaps D 
      passes collider and collidee to callback for each pair
        ✓ A-C 
        ✓ A-D 
        ✓ B-C 
        ✓ B-D 
        ✓ A-B-C 
        ✓ A-B-D 
        ✓ A-C-D 
        ✓ B-C-D 
        ✓ A-C, B-D 
        ✓ A-D, B-C 
        ✓ A-B-C-D 
    group.bounce(sprite)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group overlaps target sprite 
      ✓ true if all sprites in group overlap target sprite 
      ✓ does not call callback when not overlapping sprite 
      true if any sprites in group overlap target sprite
        ✓ A overlaps C 
        ✓ B overlaps C 
      passes collider and collidee to callback for each overlap
        ✓ A-C 
        ✓ B-C 
        ✓ A-B-C 
    group.bounce(group)
      ✓ false if no sprites overlap 
      ✓ false if no sprite in group AB overlaps any sprite in group CD 
      ✓ true if all sprites in group AB overlap all sprites in group CD 
      ✓ group does not overlap self if no sprites within group overlap 
      ✓ group overlaps self if two different sprites within group overlap 
      ✓ does not call callback when not overlapping any sprites 
      true if any sprites in group AB overlap any sprites in group CD
        ✓ A overlaps C 
        ✓ A overlaps D 
        ✓ B overlaps C 
        ✓ B overlaps D 
      passes collider and collidee to callback for each pair
        ✓ A-C 
        ✓ A-D 
        ✓ B-C 
        ✓ B-D 
        ✓ A-B-C 
        ✓ A-B-D 
        ✓ A-C-D 
        ✓ B-C-D 
        ✓ A-C, B-D 
        ✓ A-D, B-C 
        ✓ A-B-C-D 
```