### PR TITLE
Add `npm run docs` command

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@ a:active, a:hover, #reference a:hover {
   *
   <a href="test/">Test Suite</a>
   *
+  <a href="docs/">Reference</a>
+  *
   <a href="https://github.com/molleindustria/p5.play/">GitHub</a>
 </div>  
 <p>Welcome to <strong>p5.play</strong> development!</p>

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -371,6 +371,7 @@ p5.prototype.keyDown = function(key) {
  * to call keyDown or other methods directly.
  *
  * @private
+ * @method _isKeyInState
  * @param {Number|String} key Key code or character
  * @param {Number} state Key state to check against
  * @return {Boolean} True if the key is in the given state
@@ -425,40 +426,41 @@ p5.prototype.mouseUp = function(buttonCode) {
 }
 
 /**
-* Detects if a mouse button was released during the last cycle.
-* It can be used to trigger events once, to be checked in the draw cycle
-*
-* @method mouseWentUp
-* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
-* @return {Boolean} True if the button was just released
-*/
+ * Detects if a mouse button was released during the last cycle.
+ * It can be used to trigger events once, to be checked in the draw cycle
+ *
+ * @method mouseWentUp
+ * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+ * @return {Boolean} True if the button was just released
+ */
 p5.prototype.mouseWentUp = function(buttonCode) {
   return this._isMouseButtonInState(buttonCode, KEY_WENT_UP);
 }
 
 
 /**
-* Detects if a mouse button was pressed during the last cycle.
-* It can be used to trigger events once, to be checked in the draw cycle
-*
-* @method mouseWentDown
-* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
-* @return {Boolean} True if the button was just pressed
-*/
+ * Detects if a mouse button was pressed during the last cycle.
+ * It can be used to trigger events once, to be checked in the draw cycle
+ *
+ * @method mouseWentDown
+ * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+ * @return {Boolean} True if the button was just pressed
+ */
 p5.prototype.mouseWentDown = function(buttonCode) {
   return this._isMouseButtonInState(buttonCode, KEY_WENT_DOWN);
 }
 
 /**
-* Detects if a mouse button is in the given state during the last cycle.
-* Helper method encapsulating common mouse button state logic; it may be
-* preferable to call mouseWentUp, etc, directly.
-*
-* @private
-* @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
-* @param {Number} state
-* @return {boolean} True if the button was in the given state
-*/
+ * Detects if a mouse button is in the given state during the last cycle.
+ * Helper method encapsulating common mouse button state logic; it may be
+ * preferable to call mouseWentUp, etc, directly.
+ *
+ * @private
+ * @method _isMouseButtonInState
+ * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
+ * @param {Number} state
+ * @return {boolean} True if the button was in the given state
+ */
 p5.prototype._isMouseButtonInState = function(buttonCode, state) {
   var mouseStates = this._p5play.mouseStates;
 
@@ -484,8 +486,9 @@ p5.prototype._isMouseButtonInState = function(buttonCode, state) {
  * An object storing all useful keys for easy access
  * Key.tab = 9
  *
- * @type {Object}
  * @private
+ * @property KEY
+ * @type {Object}
  */
 var KEY = p5.prototype.KEY = {
     'BACKSPACE': 8,
@@ -586,8 +589,9 @@ var KEY = p5.prototype.KEY = {
  * An object storing deprecated key aliases, which we still support but
  * should be mapped to valid aliases and generate warnings.
  *
- * @type {Object}
  * @private
+ * @property KEY_DEPRECATIONS
+ * @type {Object}
  */
 p5.prototype.KEY_DEPRECATIONS = {
   'MINUT': 'MINUS',
@@ -602,6 +606,7 @@ p5.prototype.KEY_DEPRECATIONS = {
  * of the deprecated alias.
  *
  * @private
+ * @method _keyCodeFromAlias
  * @param {!string} alias - a case-insensitive key alias
  * @return {number|undefined} a numeric JavaScript key code, or undefined
  *          if no key code matching the given alias is found.
@@ -1244,9 +1249,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
   };//end update
 
   /**
-  * Creates a default collider matching the size of the
-  * placeholder rectangle or the bounding box of the image.
-  */
+   * Creates a default collider matching the size of the
+   * placeholder rectangle or the bounding box of the image.
+   *
+   * @method setDefaultCollider
+   */
   this.setDefaultCollider = function() {
 
     //if has animation get the animation bounding box
@@ -1276,9 +1283,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
   };
 
   /**
-  * Updates the sprite mouse states and triggers the mouse events:
-  * onMouseOver, onMouseOut, onMousePressed, onMouseReleased
-  */
+   * Updates the sprite mouse states and triggers the mouse events:
+   * onMouseOver, onMouseOut, onMousePressed, onMouseReleased
+   *
+   * @method mouseUpdate
+   */
   this.mouseUpdate = function() {
 
     var mouseWasOver = this.mouseIsOver;
@@ -1373,7 +1382,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this.setCollider = function(type, offsetX, offsetY, width, height) {
 
-  this.colliderType = "custom";
+    this.colliderType = "custom";
 
     if(type=="rectangle" && arguments.length==5)
       this.collider = new AABB(pInst, this.position, createVector(arguments[3], arguments[4]), createVector(arguments[1],arguments[2]) );
@@ -1392,8 +1401,9 @@ function Sprite(pInst, _x, _y, _w, _h) {
   }
 
   /**
-  * Returns a the bounding box of the current image
-  */
+   * Returns a the bounding box of the current image
+   * @method getBoundingBox
+   */
   this.getBoundingBox = function() {
 
     var w = animations[currentAnimation].getWidth()*abs(this.scale);
@@ -1446,9 +1456,12 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
 
   /**
-  * Manages the positioning, scale and rotation of the sprite
-  * Called automatically, it should not be overridden
-  */
+   * Manages the positioning, scale and rotation of the sprite
+   * Called automatically, it should not be overridden
+   * @private
+   * @final
+   * @method display
+   */
   this.display = function()
   {
     if (this.visible && !this.removed)
@@ -1995,8 +2008,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
   }
 
   /**
-  * Internal collision detection function. Do not use directly.
-  */
+   * Internal collision detection function. Do not use directly.
+   * @private
+   * @method
+   */
   this.AABBops = function(type, target, callback) {
 
     this.touching.left = false;
@@ -2455,8 +2470,9 @@ function Group() {
   };
 
   /**
-  * Same as Group.contains
-  */
+   * Same as Group.contains
+   * @method indexOf
+   */
   array.indexOf = function(item) {
     for (var i = 0, len = array.length; i < len; ++i) {
       if (virtEquals(item, array[i])) {
@@ -2470,7 +2486,7 @@ function Group() {
   * Adds a sprite to the group.
   *
   * @method add
-  * @param {Sprite} sprite The sprite to be added
+  * @param {Sprite} s The sprite to be added
   */
   array.add = function(s) {
 
@@ -2486,8 +2502,9 @@ function Group() {
   };
 
   /**
-  * Same as group.length
-  */
+   * Same as group.length
+   * @method size
+   */
   array.size = function() {
     return array.length;
   };
@@ -2520,7 +2537,7 @@ function Group() {
   * Does not remove the actual sprite, only the affiliation (reference).
   *
   * @method remove
-  * @param {Sprite} sprite The sprite to be removed
+  * @param {Sprite} item The sprite to be removed
   * @return {Boolean} True if sprite was found and removed
   */
   array.remove = function(item) {
@@ -2537,8 +2554,9 @@ function Group() {
   };
 
   /**
-  * Returns a copy of the group as standard array.
-  */
+   * Returns a copy of the group as standard array.
+   * @method toArray
+   */
   array.toArray = function() {
     return array.slice(0);
   };
@@ -3651,6 +3669,7 @@ function SpriteSheet(pInst) {
   /**
    * Generate the frames data for this sprite sheet baesd on user params
    * @private
+   * @method _generateSheetFrames
    */
   this._generateSheetFrames = function() {
     var sX = 0, sY = 0;

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -237,7 +237,7 @@ p5.prototype.getSprites = function() {
 * sketch.
 * The drawing order is determined by the Sprite property "depth"
 *
-* @methid drawSprites
+* @method drawSprites
 * @param {Group} [group] Group of Sprites to be displayed
 */
 p5.prototype.drawSprites = function(group) {

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -321,17 +321,10 @@ defineLazyP5Property('_p5play', function() {
   };
 });
 
-/** @typedef {number} KeyState */
-
-/** @type {KeyState} */
 var KEY_IS_UP = 0;
-/** @type {KeyState} */
 var KEY_WENT_DOWN = 1;
-/** @type {KeyState} */
 var KEY_IS_DOWN = 2;
-/** @type {KeyState} */
 var KEY_WENT_UP = 3;
-
 
 /**
 * Detects if a key was pressed during the last cycle.
@@ -379,7 +372,7 @@ p5.prototype.keyDown = function(key) {
  *
  * @private
  * @param {Number|String} key Key code or character
- * @param {KeyState} state Key state to check against
+ * @param {Number} state Key state to check against
  * @return {Boolean} True if the key is in the given state
  */
 p5.prototype._isKeyInState = function(key, state) {
@@ -463,7 +456,7 @@ p5.prototype.mouseWentDown = function(buttonCode) {
 *
 * @private
 * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
-* @param {KeyState} state
+* @param {Number} state
 * @return {boolean} True if the button was in the given state
 */
 p5.prototype._isMouseButtonInState = function(buttonCode, state) {

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -373,16 +373,15 @@ p5.prototype.keyDown = function(key) {
 }
 
 /**
-* Detects if a key is in the given state during the last cycle.
-* Helper method encapsulating common key state logic; it may be preferable
-* to call keyDown or other methods directly.
-*
-* @method _isKeyInState
-* @param {Number|String} key Key code or character
-* @param {KeyState} state Key state to check against
-* @return {Boolean} True if the key is in the given state
-* @private
-*/
+ * Detects if a key is in the given state during the last cycle.
+ * Helper method encapsulating common key state logic; it may be preferable
+ * to call keyDown or other methods directly.
+ *
+ * @private
+ * @param {Number|String} key Key code or character
+ * @param {KeyState} state Key state to check against
+ * @return {Boolean} True if the key is in the given state
+ */
 p5.prototype._isKeyInState = function(key, state) {
   var keyCode;
   var keyStates = this._p5play.keyStates;
@@ -462,11 +461,10 @@ p5.prototype.mouseWentDown = function(buttonCode) {
 * Helper method encapsulating common mouse button state logic; it may be
 * preferable to call mouseWentUp, etc, directly.
 *
-* @method _isMouseButtonInState
+* @private
 * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @param {KeyState} state
 * @returns {boolean} True if the button was in the given state
-* @private
 */
 p5.prototype._isMouseButtonInState = function(buttonCode, state) {
   var mouseStates = this._p5play.mouseStates;
@@ -490,14 +488,12 @@ p5.prototype._isMouseButtonInState = function(buttonCode, state) {
 
 
 /**
-* An object storing all useful keys for easy access
-* Key.tab = 9
-*
-* @property KEY
-* @type {Object}
-*/
-
-
+ * An object storing all useful keys for easy access
+ * Key.tab = 9
+ *
+ * @type {Object}
+ * @private
+ */
 var KEY = p5.prototype.KEY = {
     'BACKSPACE': 8,
     'TAB': 9,
@@ -597,8 +593,8 @@ var KEY = p5.prototype.KEY = {
  * An object storing deprecated key aliases, which we still support but
  * should be mapped to valid aliases and generate warnings.
  *
- * @property KEY_DEPRECATIONS
  * @type {Object}
+ * @private
  */
 p5.prototype.KEY_DEPRECATIONS = {
   'MINUT': 'MINUS',
@@ -612,11 +608,10 @@ p5.prototype.KEY_DEPRECATIONS = {
  * mapped to a valid key code, but will also generate a warning about use
  * of the deprecated alias.
  *
- * @method _keyCodeFromAlias
+ * @private
  * @param {!string} alias - a case-insensitive key alias
  * @returns {number|undefined} a numeric JavaScript key code, or undefined
  *          if no key code matching the given alias is found.
- * @private
  */
 p5.prototype._keyCodeFromAlias = function (alias) {
   alias = alias.toUpperCase();

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -464,7 +464,7 @@ p5.prototype.mouseWentDown = function(buttonCode) {
 * @private
 * @param {Number} [buttonCode] Mouse button constant LEFT, RIGHT or CENTER
 * @param {KeyState} state
-* @returns {boolean} True if the button was in the given state
+* @return {boolean} True if the button was in the given state
 */
 p5.prototype._isMouseButtonInState = function(buttonCode, state) {
   var mouseStates = this._p5play.mouseStates;
@@ -610,7 +610,7 @@ p5.prototype.KEY_DEPRECATIONS = {
  *
  * @private
  * @param {!string} alias - a case-insensitive key alias
- * @returns {number|undefined} a numeric JavaScript key code, or undefined
+ * @return {number|undefined} a numeric JavaScript key code, or undefined
  *          if no key code matching the given alias is found.
  */
 p5.prototype._keyCodeFromAlias = function (alias) {
@@ -1425,7 +1425,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   *
   * @method mirrorX
   * @param {Number} dir Either 1 or -1
-  * @returns {Number} Current mirroring if no parameter is specified
+  * @return {Number} Current mirroring if no parameter is specified
   */
   this.mirrorX = function(dir) {
     if(dir == 1 || dir == -1)
@@ -1442,7 +1442,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   *
   * @method mirrorY
   * @param {Number} dir Either 1 or -1
-  * @returns {Number} Current mirroring if no parameter is specified
+  * @return {Number} Current mirroring if no parameter is specified
   */
   this.mirrorY = function(dir) {
     if(dir == 1 || dir == -1)
@@ -1808,7 +1808,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @method overlapPixel
   * @param {Number} pointX x coordinate of the point to check
   * @param {Number} pointY y coordinate of the point to check
-  * @returns {Boolean} result True if non-transparent
+  * @return {Boolean} result True if non-transparent
   */
   this.overlapPixel = function(pointX, pointY) {
 
@@ -1843,7 +1843,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @method overlapPoint
   * @param {Number} pointX x coordinate of the point to check
   * @param {Number} pointY y coordinate of the point to check
-  * @returns {Boolean} result True if inside
+  * @return {Boolean} result True if inside
   */
   this.overlapPoint = function(pointX, pointY) {
     var point = createVector(arguments[0], arguments[1]);
@@ -1894,7 +1894,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @method overlap
   * @param {Object} target Sprite or group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   this.overlap = function(target, callback) {
     //if(this.collider instanceof AABB && target.collider instanceof AABB)
@@ -1928,7 +1928,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @method collide
   * @param {Object} target Sprite or group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   this.collide = function(target, callback) {
     //if(this.collider instanceof AABB && target.collider instanceof AABB)
@@ -1962,7 +1962,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @method displace
   * @param {Object} target Sprite or group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   this.displace = function(target, callback) {
     return this.AABBops("displace", target, callback);
@@ -1995,7 +1995,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @method bounce
   * @param {Object} target Sprite or group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   this.bounce = function(target, callback) {
     return this.AABBops("bounce", target, callback);
@@ -2637,7 +2637,7 @@ function Group() {
    * @param {!string} type one of 'overlap', 'collide', 'displace', 'bounce'
    * @param {Object} target Group or Sprite
    * @param {Function} [callback] on collision.
-   * @returns {boolean} True if any collision/overlap occurred
+   * @return {boolean} True if any collision/overlap occurred
    */
   function _groupCollide(type, target, callback) {
     var didCollide = false;
@@ -2670,7 +2670,7 @@ function Group() {
   * @method overlap
   * @param {Object} target Group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   array.overlap = _groupCollide.bind(array, 'overlap');
 
@@ -2702,7 +2702,7 @@ function Group() {
   * @method overlap
   * @param {Object} target Group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   array.collide = _groupCollide.bind(array, 'collide');
 
@@ -2733,7 +2733,7 @@ function Group() {
   * @method displace
   * @param {Object} target Group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   array.displace = _groupCollide.bind(array, 'displace');
 
@@ -2764,7 +2764,7 @@ function Group() {
   * @method bounce
   * @param {Object} target Group to check against the current one
   * @param {Function} [callback] The function to be called if overlap is positive
-  * @returns {Boolean} True if overlapping
+  * @return {Boolean} True if overlapping
   */
   array.bounce = _groupCollide.bind(array, 'bounce');
 

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "p5.play",
   "version": "1.0.0",
   "description": "A p5.js library for the creation of games and playthings.",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "http-server": "^0.9.0",
     "jshint": "^2.9.1",
-    "mocha-phantomjs": "^4.0.1"
+    "mocha-phantomjs": "^4.0.1",
+    "yuidocjs": "^0.10.0"
   },
   "scripts": {
+    "docs": "yuidoc .",
     "lint": "jshint lib/",
     "start": "http-server -o",
     "test": "mocha-phantomjs test/index.html"

--- a/theme/partials/options.handlebars
+++ b/theme/partials/options.handlebars
@@ -11,7 +11,7 @@
         </label>
 
         <label for="api-show-private" class="checkbox">
-            <input type="checkbox" id="api-show-private">
+            <input type="checkbox" id="api-show-private" checked>
             Private
         </label>
         <label for="api-show-deprecated" class="checkbox">

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -7,7 +7,7 @@
     "options": {
         "outdir": "docs",
       
-        "exclude": "examples,docs",
+        "exclude": "examples,docs,test",
         "themedir": "theme",
         "helpers": ["theme/helpers/helpers.js"]
     }

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -7,7 +7,7 @@
     "options": {
         "outdir": "docs",
       
-        "exclude": "examples,docs,test",
+        "exclude": "examples,docs,test,theme",
         "themedir": "theme",
         "helpers": ["theme/helpers/helpers.js"]
     }


### PR DESCRIPTION
Adds an `npm run docs` task to regenerate the p5.play documentation, per issue #41.

Details:

* Does some cleanup of warnings I found when generating the docs
* Adds a link on the `npm start` local dev start page to the local documentation
* I noticed an issue where private methods show up in the documentation table of contents, even when the option to show private methods is unchecked.  I couldn't figure out how to fix this in the underlying YUIDoc theme, so for now I've checked the "show private methods" option by default to minimize confusion.

Does not update the checked-in documentation; I'll do that in another PR, for clarity.

