### PR TITLE
Do not double-add sprites to groups (Fixes #37)

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2513,10 +2513,9 @@ function Group() {
   * @method clear
   */
   array.removeSprites = function() {
-    var arrayLength = array.length;
-
-    for(var i = 0; i<arrayLength; i++)
+    while (array.length > 0) {
       array[0].remove();
+    }
   }
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1548,9 +1548,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     quadTree.removeObject(this);
 
     //when removed from the "scene" also remove all the references in all the groups
-    for(var i=0; i<this.groups.length; i++)
-    {
-      this.groups[i].remove(this);
+    while (this.groups.length > 0) {
+      this.groups[0].remove(this);
     }
   }
 
@@ -2543,13 +2542,22 @@ function Group() {
       throw("Error: you can only remove sprites from a group");
     }
 
-    var removed = false;
-    for (var i = array.length - 1; i >= 0; i--) {
+    var i, removed = false;
+    for (i = array.length - 1; i >= 0; i--) {
       if (array[i] === item) {
         array.splice(i, 1);
         removed = true;
       }
     }
+
+    if (removed) {
+      for (i = item.groups.length - 1; i >= 0; i--) {
+        if (item.groups[i] === this) {
+          item.groups.splice(i, 1);
+        }
+      }
+    }
+
     return removed;
   };
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2489,16 +2489,12 @@ function Group() {
   * @param {Sprite} s The sprite to be added
   */
   array.add = function(s) {
-
-    if(s instanceof Sprite == false)
+    if(!(s instanceof Sprite)) {
       throw("Error: you can only add sprites to a group");
-    else
-    {
-      array.push(s); // for add(Object)
-      s.groups.push(this);
-      //next to do add a reference to the group in the sprite
-      //so when I remove it I can remove it from all groups
     }
+
+    array.push(s);
+    s.groups.push(this);
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2539,16 +2539,18 @@ function Group() {
   * @return {Boolean} True if sprite was found and removed
   */
   array.remove = function(item) {
-
-    if(item instanceof Sprite == false)
+    if(!(item instanceof Sprite)) {
       throw("Error: you can only remove sprites from a group");
-
-    item = this.indexOf(item);
-    if (item > -1) {
-      array.splice(item, 1);
-      return true;
     }
-    return false;
+
+    var removed = false;
+    for (var i = array.length - 1; i >= 0; i--) {
+      if (array[i] === item) {
+        array.splice(i, 1);
+        removed = true;
+      }
+    }
+    return removed;
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2493,8 +2493,10 @@ function Group() {
       throw("Error: you can only add sprites to a group");
     }
 
-    array.push(s);
-    s.groups.push(this);
+    if (-1 === this.indexOf(s)) {
+      array.push(s);
+      s.groups.push(this);
+    }
   };
 
   /**

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -1,18 +1,48 @@
 describe('Group', function() {
-  var pInst;
+  var pInst, group;
 
   beforeEach(function() {
     pInst = new p5(function() {});
+    group = new pInst.Group();
   });
 
   afterEach(function() {
     pInst.remove();
   });
 
+  it("is an array", function () {
+    expect(Array.isArray(group));
+  });
+
+  describe("add()", function () {
+    it("adds a sprite to the group", function () {
+      var sprite = pInst.createSprite();
+      group.add(sprite);
+      expect(group).to.include(sprite);
+      expect(group[0]).to.equal(sprite);
+      expect(group.contains(sprite)).to.be.at.least(0);
+    });
+
+    it("lets you add different sprites to the group", function () {
+      var sprite1 = pInst.createSprite();
+      var sprite2 = pInst.createSprite();
+      group.add(sprite1);
+      group.add(sprite2);
+      expect(group.length).to.equal(2);
+    });
+
+    it("ignores double addition of a unique sprite", function () {
+      var sprite = pInst.createSprite();
+      group.add(sprite);
+      group.add(sprite);
+      expect(group.length).to.equal(1);
+      expect(group[0]).to.equal(sprite);
+      expect(group[1]).to.be.undefined;
+    });
+  });
+
   describe("removeSprites()", function() {
     it("should remove all sprites", function() {
-      var group = new pInst.Group();
-
       expect(group.size()).to.equal(0);
       expect(pInst.allSprites.size()).to.equal(0);
 

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -49,10 +49,22 @@ describe('Group', function() {
       group.add(sprite2);
       expect(group.length).to.equal(2);
 
-      group.remove(sprite1);
+      var result = group.remove(sprite1);
+      expect(result).to.be.true;
       expect(group.length).to.equal(1);
       expect(group.contains(sprite1)).to.be.false;
       expect(group.contains(sprite2)).to.be.true;
+    });
+
+    it("returns false if the sprite is not a member of the group", function () {
+      var sprite1 = pInst.createSprite();
+      var sprite2 = pInst.createSprite();
+      group.add(sprite1);
+      expect(group.length).to.equal(1);
+
+      var result = group.remove(sprite2);
+      expect(result).to.be.false;
+      expect(group.length).to.equal(1);
     });
 
     it("throws if passed something besides a sprite", function () {

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -67,6 +67,20 @@ describe('Group', function() {
       expect(group.length).to.equal(1);
     });
 
+    it("removes all copies of a sprite if more than one happen to be present", function () {
+      // This shouldn't happen when using a group properly, but just in case let's
+      // make sure we clean up properly.
+      var sprite = pInst.createSprite();
+      group.add(sprite);
+      group.push(sprite);
+      expect(group.length).to.equal(2);
+      expect(group[0]).to.equal(sprite);
+      expect(group[1]).to.equal(sprite);
+
+      group.remove(sprite);
+      expect(group.length).to.equal(0);
+    });
+
     it("throws if passed something besides a sprite", function () {
       [
         null,

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -23,6 +23,12 @@ describe('Group', function() {
       expect(group.contains(sprite)).to.be.true;
     });
 
+    it("gives the sprite a reference to itself", function () {
+      var sprite = pInst.createSprite();
+      group.add(sprite);
+      expect(sprite.groups).to.include(group);
+    });
+
     it("lets you add different sprites to the group", function () {
       var sprite1 = pInst.createSprite();
       var sprite2 = pInst.createSprite();
@@ -70,6 +76,14 @@ describe('Group', function() {
       expect(group.length).to.equal(1);
       expect(group.contains(sprite1)).to.be.false;
       expect(group.contains(sprite2)).to.be.true;
+    });
+
+    it("removes the sprite's reference to itself", function () {
+      var sprite = pInst.createSprite();
+      group.add(sprite);
+      expect(sprite.groups).to.include(group);
+      group.remove(sprite);
+      expect(sprite.groups).to.not.include(group);
     });
 
     it("returns false if the sprite is not a member of the group", function () {

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -11,7 +11,7 @@ describe('Group', function() {
   });
 
   it("is an array", function () {
-    expect(Array.isArray(group));
+    expect(Array.isArray(group)).to.be.true;
   });
 
   describe("add()", function () {
@@ -20,7 +20,7 @@ describe('Group', function() {
       group.add(sprite);
       expect(group).to.include(sprite);
       expect(group[0]).to.equal(sprite);
-      expect(group.contains(sprite)).to.be.at.least(0);
+      expect(group.contains(sprite)).to.be.true;
     });
 
     it("lets you add different sprites to the group", function () {
@@ -38,6 +38,21 @@ describe('Group', function() {
       expect(group.length).to.equal(1);
       expect(group[0]).to.equal(sprite);
       expect(group[1]).to.be.undefined;
+    });
+  });
+
+  describe("remove()", function () {
+    it("removes a sprite from the group", function () {
+      var sprite1 = pInst.createSprite();
+      var sprite2 = pInst.createSprite();
+      group.add(sprite1);
+      group.add(sprite2);
+      expect(group.length).to.equal(2);
+
+      group.remove(sprite1);
+      expect(group.length).to.equal(1);
+      expect(group.contains(sprite1)).to.be.false;
+      expect(group.contains(sprite2)).to.be.true;
     });
   });
 

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -39,6 +39,22 @@ describe('Group', function() {
       expect(group[0]).to.equal(sprite);
       expect(group[1]).to.be.undefined;
     });
+
+    it("throws if passed something besides a sprite", function () {
+      [
+        null,
+        undefined,
+        3.14,
+        'string',
+        [],
+        {},
+        new Error('error')
+      ].forEach(function (item) {
+        expect(function () {
+          group.add(item)
+        }).throws('Error: you can only add sprites to a group');
+      });
+    });
   });
 
   describe("remove()", function () {

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -54,6 +54,22 @@ describe('Group', function() {
       expect(group.contains(sprite1)).to.be.false;
       expect(group.contains(sprite2)).to.be.true;
     });
+
+    it("throws if passed something besides a sprite", function () {
+      [
+        null,
+        undefined,
+        3.14,
+        'string',
+        [],
+        {},
+        new Error('error')
+      ].forEach(function (item) {
+        expect(function () {
+          group.remove(item)
+        }).throws('Error: you can only remove sprites from a group');
+      });
+    });
   });
 
   describe("removeSprites()", function() {


### PR DESCRIPTION
Adds some simple tests around `Group.add()` and `Group.remove()`, and fixes the following bugs:

* It's no longer possible to add a sprite to a group more than once through `Group.add()`.  Trying to do so is a silent no-op.  (Fixes #37)
* `Group.remove(sprite)` now removes all copies of a sprite from a group - while this shouldn't happen in normal use, it's still possible to get a sprite copy into a group via standard array methods.
* `Group.remove(sprite)` now removes the sprite's reference back to the group that was added by `Group.add()`.

And had to do the following cleanup along the way:
* `Sprite.remove()` and `Group.removeSprites()` iterate more safely, less likely to skip groups/sprites if the array is modified during iteration.

Group tests after this change:
```
  Group
    ✓ is an array 
    add()
      ✓ adds a sprite to the group 
      ✓ gives the sprite a reference to itself 
      ✓ lets you add different sprites to the group 
      ✓ ignores double addition of a unique sprite 
      ✓ throws if passed something besides a sprite 
    remove()
      ✓ removes a sprite from the group 
      ✓ removes the sprite's reference to itself 
      ✓ returns false if the sprite is not a member of the group 
      ✓ removes all copies of a sprite if more than one happen to be present 
      ✓ throws if passed something besides a sprite 
    removeSprites()
      ✓ should remove all sprites 
```