### PR TITLE
Fix #49: Allow circle collisions to bounce at oblique angles

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2164,6 +2164,27 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
               if(type == "bounce")
               {
+                if (this.collider instanceof CircleCollider && other.collider instanceof CircleCollider) {
+                  var dx1 = p5.Vector.sub(this.position, other.position);
+                  var dx2 = p5.Vector.sub(other.position, this.position);
+                  var magnitude = dx1.magSq();
+                  var totalMass = this.mass + other.mass;
+                  var m1 = 0, m2 = 0;
+                  if (this.immovable) {
+                    m2 = 2;
+                  } else if (other.immovable) {
+                    m1 = 2;
+                  } else {
+                    m1 = 2 * other.mass / totalMass;
+                    m2 = 2 * this.mass / totalMass;
+                  }
+                  var newVel1 = dx1.mult(m1 * p5.Vector.sub(this.velocity, other.velocity).dot(dx1) / magnitude);
+                  var newVel2 = dx2.mult(m2 * p5.Vector.sub(other.velocity, this.velocity).dot(dx2) / magnitude);
+
+                  this.velocity.sub(newVel1.mult(this.restitution));
+                  other.velocity.sub(newVel2.mult(other.restitution));
+                }
+                else {
                 if(other.immovable)
                 {
                   var newVelX1 = -this.velocity.x+other.velocity.x;
@@ -2211,6 +2232,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
                   if(!other.immovable)
                     other.velocity.y = newVelY2*other.restitution;
+                }
                 }
               }
               //else if(type == "collide")


### PR DESCRIPTION
Fix for #49.  Implements 2d circle-circle elastic collisions based on this formula from https://en.wikipedia.org/wiki/Elastic_collision#Two-dimensional:

![3a70e57f4a5cc0e5e0e11be153aa4b10](https://cloud.githubusercontent.com/assets/413693/13937171/1934290a-ef80-11e5-93d5-3d45e1036920.png)

Demo here: https://jsfiddle.net/6p5wk8g1/show

---

Before to this change, velocity is only adjusted along one axis:

![bounce_before](https://cloud.githubusercontent.com/assets/413693/13895954/e28531e0-ed38-11e5-8df6-ad1d53b9247e.gif)

After this change, oblique bounce angles are possible:

![bounce_after](https://cloud.githubusercontent.com/assets/413693/13895962/0cfc078c-ed39-11e5-904f-6a7bc86179cb.gif)

Examples generated with the following repro:
```javascript
var s, g, ball;

function setup() {
  createCanvas(400, 400);
  g = new Group();
  
  s = createSprite(100, 100, 0, 0);
  s.setCollider('circle', 0, 0, 50);
  s.immovable = true;
  s.debug = true;
  g.add(s);
  
  s = createSprite(300, 300, 0, 0);
  s.setCollider('circle', 0, 0, 50);
  s.immovable = true;
  s.debug = true;
  g.add(s);
  
  ball = createSprite(200, 200, 0, 0);
  ball.setCollider('circle', 0, 0, 10);
  ball.debug = true;
  ball.velocity.x = 5;
  ball.velocity.y = 5;
}

function draw() {
  background('#fff');
  ball.bounce(g);
  drawSprites();
}
```