### PR TITLE
Fix incorrect rendering by initializing constants later

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -107,13 +107,6 @@ function createPInstBinder(pInst) {
   };
 }
 
-// These are p5 constants that we'd like easy access to.
-var RGB = p5.prototype.RGB;
-var CENTER = p5.prototype.CENTER;
-var LEFT = p5.prototype.LEFT;
-var BOTTOM = p5.prototype.BOTTOM;
-var PI = p5.prototype.PI;
-
 // These are utility p5 functions that don't depend on p5 instance state in
 // order to work properly, so we'll go ahead and make them easy to
 // access without needing to bind them to a p5 instance.
@@ -764,6 +757,13 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
   var quadTree = pInst.quadTree;
   var camera = pInst.camera;
+
+
+  // These are p5 constants that we'd like easy access to.
+  var RGB = p5.prototype.RGB;
+  var CENTER = p5.prototype.CENTER;
+  var LEFT = p5.prototype.LEFT;
+  var BOTTOM = p5.prototype.BOTTOM;
 
   /**
   * The sprite's position of the sprite as a vector (x,y).
@@ -2797,6 +2797,8 @@ function CircleCollider(pInst, _center, _radius, _offset) {
 
   var createVector = pInstBind('createVector');
 
+  var CENTER = p5.prototype.CENTER;
+
   this.center = _center;
   this.radius = _radius;
   this.originalRadius = _radius;
@@ -2877,6 +2879,9 @@ function AABB(pInst, _center, _extents, _offset) {
   var pInstBind = createPInstBinder(pInst);
 
   var createVector = pInstBind('createVector');
+
+  var CENTER = p5.prototype.CENTER;
+  var PI = p5.prototype.PI;
 
   this.center = _center;
   this.extents = _extents;
@@ -3167,6 +3172,8 @@ function AABB(pInst, _center, _extents, _offset) {
 
 function Animation(pInst) {
   arguments = Array.prototype.slice.call(arguments, 1);
+
+  var CENTER = p5.prototype.CENTER;
 
   /**
   * Array of frames (p5.Image)

--- a/test/index.html
+++ b/test/index.html
@@ -18,10 +18,11 @@
     <script src="../lib/p5.play.js"></script>
     <script src="unit/collisions.js"></script>
     <script src="unit/group.js"></script>
-    <script src="unit/keycodes.js"></script>
     <script src="unit/input.js"></script>
-    <script src="unit/spritesheet.js"></script>
+    <script src="unit/keycodes.js"></script>
     <script src="unit/sketch-properties.js"></script>
+    <script src="unit/sprite.js"></script>
+    <script src="unit/spritesheet.js"></script>
 
     <!-- Keep these at the end of the test list since they run slooooow. -->
     <script src="unit/examples.js"></script>

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -1,0 +1,36 @@
+describe('Sprite', function() {
+  var pInst;
+
+  beforeEach(function () {
+    pInst = new p5(function () {});
+  });
+
+  afterEach(function () {
+    pInst.remove();
+  });
+
+  it("sets correct coordinate mode for rendering", function () {
+    // Note: This test reaches into p5's internals somewhat more than usual.
+    // It's designed to catch a particular rendering regression reported in
+    // issue #48, where certain local constants are initialized incorrectly.
+    // See https://github.com/molleindustria/p5.play/issues/48
+    expect(p5.prototype.CENTER).to.not.be.undefined;
+    var rectMode = undefined,
+        ellipseMode = undefined,
+        imageMode = undefined;
+
+    // Monkeypatch sprite's draw method to inspect coordinate mode at draw-time.
+    var sprite = pInst.createSprite();
+    sprite.draw = function () {
+      rectMode = pInst._renderer._rectMode;
+      ellipseMode = pInst._renderer._ellipseMode;
+      imageMode = pInst._renderer._imageMode;
+    };
+    pInst.drawSprites();
+
+    // Check captured modes.
+    expect(rectMode).to.equal(p5.prototype.CENTER);
+    expect(ellipseMode).to.equal(p5.prototype.CENTER);
+    expect(imageMode).to.equal(p5.prototype.CENTER);
+  });
+});


### PR DESCRIPTION
@cpirich fixed #48 downstream in code-dot-org/code-dot-org#7415.  I've manually extracted just the fix to when constants are initialized, and added a simple unit test to cover the issue.

The test reaches further into p5 rendering details than I'd like, but it checks the misinitialized `CENTER` constant right where it's used, and would complain if anything else changed the default coordinate mode for Sprite rendering, so it seems useful.

@gtoast I used the repro sketch you provided to verify that this fixes the issue you reported.  Please take a look and let me know if you see any problem with this.