### PR TITLE
Expose CircleCollider and AABB.

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2873,6 +2873,7 @@ function CircleCollider(pInst, _center, _radius, _offset) {
 
 
 }
+defineLazyP5Property('CircleCollider', boundConstructorFactory(CircleCollider));
 
 //axis aligned bounding box - extents are the half sizes - used internally
 function AABB(pInst, _center, _extents, _offset) {
@@ -3123,6 +3124,7 @@ function AABB(pInst, _center, _extents, _offset) {
 
 
 }//end AABB
+defineLazyP5Property('AABB', boundConstructorFactory(AABB));
 
 
 


### PR DESCRIPTION
Exposes the CircleCollider and AABB classes on the p5 prototype.  They are still primarily for internal use, but exposing them can be useful for other applications intending to integrate or extend the library.

This is a selfish change; in our own application, we extend p5.play to run in a sandboxed environment.  To do this we actually monkeypatch our own versions of certain methods (in particular, methods with callbacks) to make the library compatiable with our sandbox.  That said, I don't think it's harmful to put these classes on the prototype for general use.

For the curious: Our patched versions of these methods are designed to accept a student-defined callback running in a sandboxed javascript interpreter.  Because the sandboxed interpreter is slow, and because we allow debugging, we want to be able to suspend execution in the middle of the student code to give our UI a chance to update.  When the student code is a callback to a p5.play method in native code, that also means suspending the library method mid-execution.  Thus, our patched versions of the library methods are split into two methods around the callback, to allow suspeding and resuming execution in student code.

See [this commit](https://github.com/code-dot-org/code-dot-org/pull/7415/commits/6b565e21116911deca115961388fb2fa65a2b205) as an example of this use.  This is the last downstream change to p5.play by @cpirich in code-dot-org/code-dot-org#7415.