### PR TITLE
Fix #54: Don't leak render state in Sprite.debug

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1484,8 +1484,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
       if(this.debug)
       {
+        push();
         //draw the anchor point
         stroke(0,255,0);
+        strokeWeight(1);
         line(this.position.x-10, this.position.y, this.position.x+10, this.position.y);
         line(this.position.x, this.position.y-10, this.position.x, this.position.y+10);
         noFill();
@@ -1505,6 +1507,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
         {
           this.collider.draw();
         }
+        pop();
       }
 
     }


### PR DESCRIPTION
Fixes #54.