### PR TITLE
Fix instance mode breakage when debug mode is active

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -744,6 +744,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   var scale = pInstBind('scale');
   var rotate = pInstBind('rotate');
   var stroke = pInstBind('stroke');
+  var strokeWeight = pInstBind('strokeWeight');
   var line = pInstBind('line');
   var noFill = pInstBind('noFill');
   var fill = pInstBind('fill');


### PR DESCRIPTION
It looks like we added a call to `strokeWeight()` in #54, but we didn't bind it to `pInst`, which meant that sketches in instance mode would crash because it wasn't defined globally.
