### PR TITLE
Don't publicly document Sprite constructor

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -716,14 +716,10 @@ deltaTime = ((now - then) / 1000)/INTERVAL_60; // seconds since last frame
    * A Sprite can have a collider that defines the active area to detect
    * collisions or overlappings with other sprites and mouse interactions.
    *
+   * To create a Sprite, use
+   * {{#crossLink "p5.play/createSprite:method"}}{{/crossLink}}.
+   *
    * @class Sprite
-   * @constructor
-   * @param {Number} x Initial x coordinate
-   * @param {Number} y Initial y coordinate
-   * @param {Number} width Width of the placeholder rectangle and of the
-   *                       collider until an image or new collider are set
-   * @param {Number} height Height of the placeholder rectangle and of the
-   *                       collider until an image or new collider are set
    */
 
 function Sprite(pInst, _x, _y, _w, _h) {

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -722,6 +722,16 @@ deltaTime = ((now - then) / 1000)/INTERVAL_60; // seconds since last frame
    * @class Sprite
    */
 
+// For details on why these docs aren't in a YUIDoc comment block, see:
+//
+// https://github.com/molleindustria/p5.play/pull/67
+//
+// @param {Number} x Initial x coordinate
+// @param {Number} y Initial y coordinate
+// @param {Number} width Width of the placeholder rectangle and of the
+//                       collider until an image or new collider are set
+// @param {Number} height Height of the placeholder rectangle and of the
+//                        collider until an image or new collider are set
 function Sprite(pInst, _x, _y, _w, _h) {
   var pInstBind = createPInstBinder(pInst);
 


### PR DESCRIPTION
This is an attempt to fix #63.

It's a bit tricky, though: documenting the constructor as `@private` actually ends up marking the entire *class* as private, which prevents [Sprite.html](http://p5play.molleindustria.org/docs/classes/Sprite.html) from being generated entirely! :disappointed: 

On top of that, it seemed impossible to add notes to the constructor advising users to use `createSprite()` instead: any documentation I tried adding either didn't show up, or it showed up in the class documentation, which is located waaaaay above the constructor. Meaning that users scrolling down to read the constructor docs likely wouldn't see the note about using `createSprite`.

So instead, I opted to simply *remove* the documentation for the constructor. It's still accessible from code, obviously, but it's undocumented now. Which IMO is probably a good thing, as it makes it that much less likely for users to accidentally use the constructor and then get confused when their sprite doesn't show up. However, it also means that there's no comments which help readers of the code understand what arguments the constructor takes. Suggestions welcome!

Oh, another thing: I'm  using YUIDoc's [`crossLink` helper](http://yui.github.io/yuidoc/syntax/index.html#cross-referencing-modules-and-classes) here to directly link to the documentation for `createSprite`, but it's actually semi-broken at present due to https://github.com/kevinlacotaco/yuidoc-bootstrap-theme/issues/24. Hopefully we can fix that soon, but at least for now it takes the user to the proper page, where they can manually find the `createSprite` method on their own.
