### PR TITLE
Fix errors in Sprite docs.

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1065,7 +1065,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * reduced by 1 unit. At 0 it will call a sprite.remove()
   * Disabled if set to -1.
   *
-  * @property removed
+  * @property life
   * @type {Number}
   * @default -1
   */
@@ -1568,7 +1568,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   *
   * @method setVelocity
   * @param {Number} x X component
-  * @param {Number} x Y component
+  * @param {Number} y Y component
   */
   this.setVelocity = function(x,y) {
     this.velocity.x = x;
@@ -1578,7 +1578,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   /**
   * Calculates the scalar speed.
   *
-  * @method setVelocity
+  * @method getSpeed
   * @return {Number} Scalar speed
   */
   this.getSpeed = function() {
@@ -2016,11 +2016,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     return this.AABBops("bounce", target, callback);
   }
 
-  /**
-   * Internal collision detection function. Do not use directly.
-   * @private
-   * @method
-   */
+  // Internal collision detection function. Do not use directly.
   this.AABBops = function(type, target, callback) {
 
     this.touching.left = false;


### PR DESCRIPTION
This fixes some inconsistencies in the Sprite docs.

It also gets rid of the following spurious method entry:

![2016-03-30_7-43-30](https://cloud.githubusercontent.com/assets/124687/14141127/26232db0-f64b-11e5-910c-d2935d17961b.png)
