### PR TITLE
Duck-type group before drawing.

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -237,7 +237,7 @@ p5.prototype.drawSprites = function(group) {
   // If no group is provided, draw the allSprites group.
   group = group || this.allSprites;
 
-  if (!(group instanceof Array))
+  if (typeof group.draw !== 'function')
   {
     throw("Error: with drawSprites you can only draw all sprites or a group");
   }


### PR DESCRIPTION
[This discussion](https://github.com/molleindustria/p5.play/pull/70/files#r57978423) led me to the conclusion that it would be less error-prone to check for the `draw()` method on the argument to `drawSprites()` than to check that it is an array - not all arrays can be `draw()`n anyway.