### PR TITLE
Style like p5js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,10 @@ module.exports = {
     "no-bitwise": "error",
     "no-caller": "error",
     "no-catch-shadow": "error",
+    "no-cond-assign": [
+      "error",
+      "except-parens"
+    ],
     "no-confusing-arrow": "error",
     "no-console": "off", // Customized: We log certain warnings
     "no-continue": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,7 +96,6 @@ module.exports = {
     "no-duplicate-imports": "error",
     "no-else-return": "off",
     "no-empty-function": "error",
-    "no-eq-null": "error",
     "no-eval": "error",
     "no-extend-native": "error",
     "no-extra-bind": "error",


### PR DESCRIPTION
Was reminded by [this discussion](https://github.com/molleindustria/p5.play/pull/76#discussion_r57971903) of the value of keeping our style rules consistent with p5js.  Here's an audit of that with some fixes.

# p5js JSHint rules
```
  "boss": true,
```
> This option suppresses warnings about the use of assignments in cases where comparisons are expected. More often than not, code like if (a = 10) {} is a typo. 

The new p5.play config is more strict than this; in keeping with the spirit of the p5js rule, I've relaxed the `no-cond-assign` rule to allow assignment in a conditional _only_ if it's wrapped in extra parens to call attention to it.

```
  "curly": true,
```
As discussed in #76 we need to do this at some point but it's going to be a large manual change.  We'll come back to this later.

```
  "eqeqeq": true,
```
Already compliant!

```
  "eqnull": true,
```
Removed the `no-eq-null` rule to be relaxed about `== null` like p5js is.

```
  "immed": true,
```
Already compliant via the `wrap-iife` rule.

```
  "latedef": "nofunc",
```
I couldn't find an ESLint rule equivalent to this.

```
  "newcap": false,
```
Already compliant by omitting `new-cap` - though I'm tempted to enable this and add `p5` as the only exception.  Thoughts?

```
  "noarg": true,
```
Already compliant through `no-caller`

```
  "quotmark": "single",
```
Already compliant through `quotes: ['error', 'single']`

```
  "trailing": true,
```
This rule is not documented for JSHint, does not apply?

```
  "undef": true,
```
Already compliant through `no-undef` which is enabled in ESLint by default.

```
  "unused": "vars",
```
p5.play is stricter through its use of `no-unused-vars` which is enabled in ESLint by default.  I'd like to leave this strict for now and modify it if it becomes an issue - this option is very configurable with regard to checking variables/arguments, or allowing unused as long as the variable is named with a certain pattern, etc.

```
  "node": true
```
Doen't apply to p5.play at this time.

# p5js JSCS rules

```
  "disallowTrailingWhitespace": true,
```
Already compliant by use of `no-trailing-spaces`

```
  "validateIndentation": 2
```
This is another rule that we need to eventually support, but will be  a very large change in its own right, and is best saved for later.