### PR TITLE
Change space-before-function-paren setting.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -197,11 +197,19 @@ module.exports = {
     "sort-imports": "error",
     "sort-vars": "off",
 
-    // I'd like to enable these four rules, but should discuss target style
-    // with the community before we do because we don't follow these at all
+    // I'd like to enable this rule, but should discuss target style
+    // with the community before we do because we don't follow it at all
     // right now.
     "space-before-blocks": "off",
-    "space-before-function-paren": "off",
+
+    "space-before-function-paren": [
+      "error",
+      "never"
+    ],
+
+    // I'd like to enable these two rules, but should discuss target style
+    // with the community before we do because we don't follow these at all
+    // right now.
     "space-in-parens": "off",
     "space-infix-ops": "off",
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4,14 +4,14 @@ by Paolo Pedercini/molleindustria, 2015
 http://molleindustria.org/
 */
 
-(function (root, factory) {
+(function(root, factory) {
 if (typeof define === 'function' && define.amd)
-define('p5.play', ['p5'], function (p5) { (factory(p5)); });
+define('p5.play', ['p5'], function(p5) { (factory(p5)); });
 else if (typeof exports === 'object')
 factory(require('../p5'));
 else
 factory(root.p5);
-}(this, function (p5) {
+}(this, function(p5) {
 /**
  * p5.play is a library for p5.js to facilitate the creation of games and gamelike
  * projects.
@@ -273,7 +273,7 @@ p5.prototype.loadAnimation = function() {
  *
  * @method loadSpriteSheet
  */
-p5.prototype.loadSpriteSheet = function () {
+p5.prototype.loadSpriteSheet = function() {
   return construct(this.SpriteSheet, arguments);
 };
 
@@ -586,7 +586,7 @@ p5.prototype.KEY_DEPRECATIONS = {
  * @return {number|undefined} a numeric JavaScript key code, or undefined
  *          if no key code matching the given alias is found.
  */
-p5.prototype._keyCodeFromAlias = function (alias) {
+p5.prototype._keyCodeFromAlias = function(alias) {
   alias = alias.toUpperCase();
   if (this.KEY_DEPRECATIONS[alias]) {
     this._warn('Key literal "' + alias + '" is deprecated and may be removed ' +
@@ -3402,7 +3402,7 @@ function Animation(pInst) {
    * @param {Number} y y coordinate
    * @param {Number} [r=0] rotation
    */
-  this.draw = function (x, y, r) {
+  this.draw = function(x, y, r) {
     this.xpos = x;
     this.ypos = y;
     this.rotation = r || 0;
@@ -3749,7 +3749,7 @@ function SpriteSheet(pInst) {
    * @param [height]  optional height to draw the frame
    * @method drawFrame
    */
-  this.drawFrame = function (frame_name, x, y, width, height) {
+  this.drawFrame = function(frame_name, x, y, width, height) {
     var frameToDraw;
     if (typeof frame_name === 'number') {
       frameToDraw = this.frames[frame_name];
@@ -4170,7 +4170,7 @@ p5.prototype.registerMethod('post', cameraPop);
  * @param {!string} message
  * @private
  */
-p5.prototype._warn = function (message) {
+p5.prototype._warn = function(message) {
   var console = window.console;
 
   if(console)

--- a/test/unit/.eslintrc.js
+++ b/test/unit/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
 
     // Eventually we want to propagate these four settings up to the main config.
     "space-before-blocks": "error",
-    "space-before-function-paren": "error",
     "space-in-parens": "error",
     "space-infix-ops": "error"
   }

--- a/test/unit/collisions.js
+++ b/test/unit/collisions.js
@@ -11,28 +11,28 @@
 /* jshint expr:true */
 /* global afterEach, beforeEach, describe, expect, it*/
 
-describe('collisions', function () {
+describe('collisions', function() {
   var SIZE = 10;
   var pInst;
   var spriteA, spriteB, spriteC, spriteD;
   var groupAB, groupCD;
   var callCount, pairs;
 
-  function testCallback (a, b) {
+  function testCallback(a, b) {
     callCount++;
     pairs.push([a.name, b.name]);
   }
 
-  function moveAToB (a, b) {
+  function moveAToB(a, b) {
     a.position.x = b.position.x;
   }
 
-  beforeEach(function () {
-    pInst = new p5(function () {});
+  beforeEach(function() {
+    pInst = new p5(function() {});
     callCount = 0;
     pairs = [];
 
-    function createTestSprite (letter, position) {
+    function createTestSprite(letter, position) {
       var sprite = pInst.createSprite(position, 0, SIZE, SIZE);
       sprite.name = 'sprite' + letter;
       return sprite;
@@ -55,30 +55,30 @@ describe('collisions', function () {
     expect(pInst.allSprites.length).to.equal(4);
     expect(groupAB.length).to.equal(2);
     expect(groupCD.length).to.equal(2);
-    pInst.allSprites.forEach(function (caller) {
-      pInst.allSprites.forEach(function (callee) {
+    pInst.allSprites.forEach(function(caller) {
+      pInst.allSprites.forEach(function(callee) {
         expect(caller.overlap(callee)).to.be.false;
       });
     });
   });
 
-  afterEach(function () {
+  afterEach(function() {
     pInst.remove();
   });
 
-  describe('sprite.overlap(sprite)', function () {
-    it('false if sprites do not overlap', function () {
+  describe('sprite.overlap(sprite)', function() {
+    it('false if sprites do not overlap', function() {
       expect(spriteA.overlap(spriteB)).to.be.false;
       expect(spriteB.overlap(spriteA)).to.be.false;
     });
 
-    it('true if sprites overlap', function () {
+    it('true if sprites overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.overlap(spriteB)).to.be.true;
       expect(spriteB.overlap(spriteA)).to.be.true;
     });
 
-    it('calls callback once if sprites overlap', function () {
+    it('calls callback once if sprites overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(callCount).to.equal(0);
       spriteA.overlap(spriteB, testCallback);
@@ -87,7 +87,7 @@ describe('collisions', function () {
       expect(callCount).to.equal(2);
     });
 
-    it('does not call callback if sprites do not overlap', function () {
+    it('does not call callback if sprites do not overlap', function() {
       expect(callCount).to.equal(0);
       spriteA.overlap(spriteB, testCallback);
       expect(callCount).to.equal(0);
@@ -95,14 +95,14 @@ describe('collisions', function () {
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-B', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-B', function() {
         moveAToB(spriteA, spriteB);
         spriteA.overlap(spriteB, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
       });
 
-      it('B-A', function () {
+      it('B-A', function() {
         moveAToB(spriteA, spriteB);
         spriteB.overlap(spriteA, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
@@ -110,78 +110,78 @@ describe('collisions', function () {
     });
   });
 
-  describe('sprite.overlap(group)', function () {
-    it('false if sprite does not overlap any sprites in group', function () {
+  describe('sprite.overlap(group)', function() {
+    it('false if sprite does not overlap any sprites in group', function() {
       expect(spriteA.overlap(groupCD)).to.be.false;
     });
 
-    it('does not check against sprites not in target group', function () {
+    it('does not check against sprites not in target group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.overlap(groupCD)).to.be.false;
     });
 
-    it('does not care if sprites in target group overlap each other', function () {
+    it('does not care if sprites in target group overlap each other', function() {
       moveAToB(spriteC, spriteD);
       expect(spriteA.overlap(groupCD)).to.be.false;
     });
 
-    it('true if sprite overlaps first sprite in group', function () {
+    it('true if sprite overlaps first sprite in group', function() {
       moveAToB(spriteA, spriteC);
       expect(spriteA.overlap(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps last sprite in group', function () {
+    it('true if sprite overlaps last sprite in group', function() {
       moveAToB(spriteA, spriteD);
       expect(spriteA.overlap(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps every sprite in group', function () {
+    it('true if sprite overlaps every sprite in group', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expect(spriteA.overlap(groupCD)).to.be.true;
     });
 
-    it('does not overlap self when checking own group', function () {
+    it('does not overlap self when checking own group', function() {
       expect(spriteA.overlap(groupAB)).to.be.false;
     });
 
-    it('can overlap with other sprites in own group', function () {
+    it('can overlap with other sprites in own group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.overlap(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       spriteA.overlap(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    it('calls callback once when overlapping one sprite', function () {
+    it('calls callback once when overlapping one sprite', function() {
       moveAToB(spriteC, spriteA);
       spriteA.overlap(groupCD, testCallback);
       expect(callCount).to.equal(1);
     });
 
-    it('calls callback twice when overlapping two sprites', function () {
+    it('calls callback twice when overlapping two sprites', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       spriteA.overlap(groupCD, testCallback);
       expect(callCount).to.equal(2);
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         spriteA.overlap(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         spriteA.overlap(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         spriteA.overlap(groupCD, testCallback);
@@ -192,13 +192,13 @@ describe('collisions', function () {
     });
   });
 
-  describe('sprite.displace(sprite)', function () {
-    it('false if sprites do not overlap', function () {
+  describe('sprite.displace(sprite)', function() {
+    it('false if sprites do not overlap', function() {
       expect(spriteA.displace(spriteB)).to.be.false;
       expect(spriteB.displace(spriteA)).to.be.false;
     });
 
-    it('true if sprites overlap', function () {
+    it('true if sprites overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.displace(spriteB)).to.be.true;
 
@@ -206,7 +206,7 @@ describe('collisions', function () {
       expect(spriteB.displace(spriteA)).to.be.true;
     });
 
-    it('calls callback once if sprites overlap', function () {
+    it('calls callback once if sprites overlap', function() {
       expect(callCount).to.equal(0);
 
       moveAToB(spriteA, spriteB);
@@ -218,7 +218,7 @@ describe('collisions', function () {
       expect(callCount).to.equal(2);
     });
 
-    it('does not call callback if sprites do not overlap', function () {
+    it('does not call callback if sprites do not overlap', function() {
       expect(callCount).to.equal(0);
       spriteA.displace(spriteB, testCallback);
       expect(callCount).to.equal(0);
@@ -226,14 +226,14 @@ describe('collisions', function () {
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-B', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-B', function() {
         moveAToB(spriteA, spriteB);
         spriteA.displace(spriteB, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
       });
 
-      it('B-A', function () {
+      it('B-A', function() {
         moveAToB(spriteA, spriteB);
         spriteB.displace(spriteA, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
@@ -241,78 +241,78 @@ describe('collisions', function () {
     });
   });
 
-  describe('sprite.displace(group)', function () {
-    it('false if sprite does not overlap any sprites in group', function () {
+  describe('sprite.displace(group)', function() {
+    it('false if sprite does not overlap any sprites in group', function() {
       expect(spriteA.displace(groupCD)).to.be.false;
     });
 
-    it('does not check against sprites not in target group', function () {
+    it('does not check against sprites not in target group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.displace(groupCD)).to.be.false;
     });
 
-    it('does not care if sprites in target group overlap each other', function () {
+    it('does not care if sprites in target group overlap each other', function() {
       moveAToB(spriteC, spriteD);
       expect(spriteA.displace(groupCD)).to.be.false;
     });
 
-    it('true if sprite overlaps first sprite in group', function () {
+    it('true if sprite overlaps first sprite in group', function() {
       moveAToB(spriteA, spriteC);
       expect(spriteA.displace(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps last sprite in group', function () {
+    it('true if sprite overlaps last sprite in group', function() {
       moveAToB(spriteA, spriteD);
       expect(spriteA.displace(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps every sprite in group', function () {
+    it('true if sprite overlaps every sprite in group', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expect(spriteA.displace(groupCD)).to.be.true;
     });
 
-    it('does not overlap self when checking own group', function () {
+    it('does not overlap self when checking own group', function() {
       expect(spriteA.displace(groupAB)).to.be.false;
     });
 
-    it('can overlap with other sprites in own group', function () {
+    it('can overlap with other sprites in own group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.displace(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       spriteA.displace(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    it('calls callback once when overlapping one sprite', function () {
+    it('calls callback once when overlapping one sprite', function() {
       moveAToB(spriteC, spriteA);
       spriteA.displace(groupCD, testCallback);
       expect(callCount).to.equal(1);
     });
 
-    it('calls callback twice when overlapping two sprites', function () {
+    it('calls callback twice when overlapping two sprites', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       spriteA.displace(groupCD, testCallback);
       expect(callCount).to.equal(2);
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         spriteA.displace(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         spriteA.displace(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         spriteA.displace(groupCD, testCallback);
@@ -323,13 +323,13 @@ describe('collisions', function () {
     });
   });
 
-  describe('sprite.collide(sprite)', function () {
-    it('false if sprites do not overlap', function () {
+  describe('sprite.collide(sprite)', function() {
+    it('false if sprites do not overlap', function() {
       expect(spriteA.collide(spriteB)).to.be.false;
       expect(spriteB.collide(spriteA)).to.be.false;
     });
 
-    it('true if sprites overlap', function () {
+    it('true if sprites overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.collide(spriteB)).to.be.true;
 
@@ -337,7 +337,7 @@ describe('collisions', function () {
       expect(spriteB.collide(spriteA)).to.be.true;
     });
 
-    it('calls callback once if sprites overlap', function () {
+    it('calls callback once if sprites overlap', function() {
       expect(callCount).to.equal(0);
 
       moveAToB(spriteA, spriteB);
@@ -349,7 +349,7 @@ describe('collisions', function () {
       expect(callCount).to.equal(2);
     });
 
-    it('does not call callback if sprites do not overlap', function () {
+    it('does not call callback if sprites do not overlap', function() {
       expect(callCount).to.equal(0);
       spriteA.collide(spriteB, testCallback);
       expect(callCount).to.equal(0);
@@ -357,14 +357,14 @@ describe('collisions', function () {
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-B', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-B', function() {
         moveAToB(spriteA, spriteB);
         spriteA.collide(spriteB, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
       });
 
-      it('B-A', function () {
+      it('B-A', function() {
         moveAToB(spriteA, spriteB);
         spriteB.collide(spriteA, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
@@ -372,58 +372,58 @@ describe('collisions', function () {
     });
   });
 
-  describe('sprite.collide(group)', function () {
-    it('false if sprite does not overlap any sprites in group', function () {
+  describe('sprite.collide(group)', function() {
+    it('false if sprite does not overlap any sprites in group', function() {
       expect(spriteA.collide(groupCD)).to.be.false;
     });
 
-    it('does not check against sprites not in target group', function () {
+    it('does not check against sprites not in target group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.collide(groupCD)).to.be.false;
     });
 
-    it('does not care if sprites in target group overlap each other', function () {
+    it('does not care if sprites in target group overlap each other', function() {
       moveAToB(spriteC, spriteD);
       expect(spriteA.collide(groupCD)).to.be.false;
     });
 
-    it('true if sprite overlaps first sprite in group', function () {
+    it('true if sprite overlaps first sprite in group', function() {
       moveAToB(spriteA, spriteC);
       expect(spriteA.collide(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps last sprite in group', function () {
+    it('true if sprite overlaps last sprite in group', function() {
       moveAToB(spriteA, spriteD);
       expect(spriteA.collide(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps every sprite in group', function () {
+    it('true if sprite overlaps every sprite in group', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expect(spriteA.collide(groupCD)).to.be.true;
     });
 
-    it('does not overlap self when checking own group', function () {
+    it('does not overlap self when checking own group', function() {
       expect(spriteA.collide(groupAB)).to.be.false;
     });
 
-    it('can overlap with other sprites in own group', function () {
+    it('can overlap with other sprites in own group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.collide(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       spriteA.collide(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    it('calls callback once when overlapping one sprite', function () {
+    it('calls callback once when overlapping one sprite', function() {
       moveAToB(spriteC, spriteA);
       spriteA.collide(groupCD, testCallback);
       expect(callCount).to.equal(1);
     });
 
-    it('calls callback twice when overlapping two sprites', function () {
+    it('calls callback twice when overlapping two sprites', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       spriteA.collide(groupCD, testCallback);
@@ -432,20 +432,20 @@ describe('collisions', function () {
       // (A-D) doesn't happen.
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         spriteA.collide(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         spriteA.collide(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         spriteA.collide(groupCD, testCallback);
@@ -457,13 +457,13 @@ describe('collisions', function () {
     });
   });
 
-  describe('sprite.bounce(sprite)', function () {
-    it('false if sprites do not overlap', function () {
+  describe('sprite.bounce(sprite)', function() {
+    it('false if sprites do not overlap', function() {
       expect(spriteA.bounce(spriteB)).to.be.false;
       expect(spriteB.bounce(spriteA)).to.be.false;
     });
 
-    it('true if sprites overlap', function () {
+    it('true if sprites overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.bounce(spriteB)).to.be.true;
 
@@ -471,7 +471,7 @@ describe('collisions', function () {
       expect(spriteB.bounce(spriteA)).to.be.true;
     });
 
-    it('calls callback once if sprites overlap', function () {
+    it('calls callback once if sprites overlap', function() {
       expect(callCount).to.equal(0);
 
       moveAToB(spriteA, spriteB);
@@ -483,7 +483,7 @@ describe('collisions', function () {
       expect(callCount).to.equal(2);
     });
 
-    it('does not call callback if sprites do not overlap', function () {
+    it('does not call callback if sprites do not overlap', function() {
       expect(callCount).to.equal(0);
       spriteA.bounce(spriteB, testCallback);
       expect(callCount).to.equal(0);
@@ -491,14 +491,14 @@ describe('collisions', function () {
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-B', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-B', function() {
         moveAToB(spriteA, spriteB);
         spriteA.bounce(spriteB, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteB.name]]);
       });
 
-      it('B-A', function () {
+      it('B-A', function() {
         moveAToB(spriteA, spriteB);
         spriteB.bounce(spriteA, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteA.name]]);
@@ -506,58 +506,58 @@ describe('collisions', function () {
     });
   });
 
-  describe('sprite.bounce(group)', function () {
-    it('false if sprite does not overlap any sprites in group', function () {
+  describe('sprite.bounce(group)', function() {
+    it('false if sprite does not overlap any sprites in group', function() {
       expect(spriteA.bounce(groupCD)).to.be.false;
     });
 
-    it('does not check against sprites not in target group', function () {
+    it('does not check against sprites not in target group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.bounce(groupCD)).to.be.false;
     });
 
-    it('does not care if sprites in target group overlap each other', function () {
+    it('does not care if sprites in target group overlap each other', function() {
       moveAToB(spriteC, spriteD);
       expect(spriteA.bounce(groupCD)).to.be.false;
     });
 
-    it('true if sprite overlaps first sprite in group', function () {
+    it('true if sprite overlaps first sprite in group', function() {
       moveAToB(spriteA, spriteC);
       expect(spriteA.bounce(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps last sprite in group', function () {
+    it('true if sprite overlaps last sprite in group', function() {
       moveAToB(spriteA, spriteD);
       expect(spriteA.bounce(groupCD)).to.be.true;
     });
 
-    it('true if sprite overlaps every sprite in group', function () {
+    it('true if sprite overlaps every sprite in group', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expect(spriteA.bounce(groupCD)).to.be.true;
     });
 
-    it('does not overlap self when checking own group', function () {
+    it('does not overlap self when checking own group', function() {
       expect(spriteA.bounce(groupAB)).to.be.false;
     });
 
-    it('can overlap with other sprites in own group', function () {
+    it('can overlap with other sprites in own group', function() {
       moveAToB(spriteA, spriteB);
       expect(spriteA.bounce(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       spriteA.bounce(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    it('calls callback once when overlapping one sprite', function () {
+    it('calls callback once when overlapping one sprite', function() {
       moveAToB(spriteC, spriteA);
       spriteA.bounce(groupCD, testCallback);
       expect(callCount).to.equal(1);
     });
 
-    it('calls callback twice when overlapping two sprites', function () {
+    it('calls callback twice when overlapping two sprites', function() {
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       spriteA.bounce(groupCD, testCallback);
@@ -566,20 +566,20 @@ describe('collisions', function () {
       // (A-D) doesn't happen.
     });
 
-    describe('passes collider and collidee to callback', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         spriteA.bounce(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         spriteA.bounce(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         spriteA.bounce(groupCD, testCallback);
@@ -591,53 +591,53 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.overlap(sprite)', function () {
-    it('false if no sprites overlap', function () {
+  describe('group.overlap(sprite)', function() {
+    it('false if no sprites overlap', function() {
       expect(groupAB.overlap(spriteC)).to.be.false;
     });
 
-    it('false if no sprite in group overlaps target sprite', function () {
+    it('false if no sprite in group overlaps target sprite', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.overlap(spriteC)).to.be.false;
     });
 
-    it('true if all sprites in group overlap target sprite', function () {
+    it('true if all sprites in group overlap target sprite', function() {
       moveAToB(spriteA, spriteC);
       moveAToB(spriteB, spriteC);
       expect(groupAB.overlap(spriteC)).to.be.true;
     });
 
-    describe('true if any sprites in group overlap target sprite', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group overlap target sprite', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expect(groupAB.overlap(spriteC)).to.be.true;
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expect(groupAB.overlap(spriteC)).to.be.true;
       });
     });
 
-    it('does not call callback when not overlapping sprite', function () {
+    it('does not call callback when not overlapping sprite', function() {
       groupAB.overlap(spriteC, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each overlap', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each overlap', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.overlap(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.overlap(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteA, spriteC);
         moveAToB(spriteB, spriteC);
         groupAB.overlap(spriteC, testCallback);
@@ -648,91 +648,91 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.overlap(group)', function () {
-    function expectGroupsOverlap (outcome) {
+  describe('group.overlap(group)', function() {
+    function expectGroupsOverlap(outcome) {
       expect(groupAB.overlap(groupCD)).to.equal(outcome);
       expect(groupCD.overlap(groupAB)).to.equal(outcome);
     }
 
-    it('false if no sprites overlap', function () {
+    it('false if no sprites overlap', function() {
       expectGroupsOverlap(false);
     });
 
-    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+    it('false if no sprite in group AB overlaps any sprite in group CD', function() {
       moveAToB(spriteA, spriteB);
       moveAToB(spriteC, spriteD);
       expectGroupsOverlap(false);
     });
 
-    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+    it('true if all sprites in group AB overlap all sprites in group CD', function() {
       moveAToB(spriteB, spriteA);
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expectGroupsOverlap(true);
     });
 
-    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group AB overlap any sprites in group CD', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expectGroupsOverlap(true);
       });
 
-      it('A overlaps D', function () {
+      it('A overlaps D', function() {
         moveAToB(spriteA, spriteD);
         expectGroupsOverlap(true);
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expectGroupsOverlap(true);
       });
 
-      it('B overlaps D', function () {
+      it('B overlaps D', function() {
         moveAToB(spriteB, spriteD);
         expectGroupsOverlap(true);
       });
     });
 
-    it('group does not overlap self if no sprites within group overlap', function () {
+    it('group does not overlap self if no sprites within group overlap', function() {
       expect(groupAB.overlap(groupAB)).to.be.false;
     });
 
-    it('group overlaps self if two different sprites within group overlap', function () {
+    it('group overlaps self if two different sprites within group overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.overlap(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       groupAB.overlap(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each pair', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each pair', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.overlap(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         groupAB.overlap(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.overlap(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('B-D', function () {
+      it('B-D', function() {
         moveAToB(spriteB, spriteD);
         groupAB.overlap(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         groupAB.overlap(groupCD, testCallback);
@@ -741,7 +741,7 @@ describe('collisions', function () {
           [spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-D', function () {
+      it('A-B-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.overlap(groupCD, testCallback);
@@ -750,7 +750,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.overlap(groupCD, testCallback);
@@ -759,7 +759,7 @@ describe('collisions', function () {
           [spriteA.name, spriteD.name]]);
       });
 
-      it('B-C-D', function () {
+      it('B-C-D', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteB);
         groupAB.overlap(groupCD, testCallback);
@@ -768,7 +768,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-C, B-D', function () {
+      it('A-C, B-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteB);
         groupAB.overlap(groupCD, testCallback);
@@ -777,7 +777,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-D, B-C', function () {
+      it('A-D, B-C', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteA);
         groupAB.overlap(groupCD, testCallback);
@@ -786,7 +786,7 @@ describe('collisions', function () {
           [spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C-D', function () {
+      it('A-B-C-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
@@ -800,53 +800,53 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.displace(sprite)', function () {
-    it('false if no sprites overlap', function () {
+  describe('group.displace(sprite)', function() {
+    it('false if no sprites overlap', function() {
       expect(groupAB.displace(spriteC)).to.be.false;
     });
 
-    it('false if no sprite in group overlaps target sprite', function () {
+    it('false if no sprite in group overlaps target sprite', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.displace(spriteC)).to.be.false;
     });
 
-    it('true if all sprites in group overlap target sprite', function () {
+    it('true if all sprites in group overlap target sprite', function() {
       moveAToB(spriteA, spriteC);
       moveAToB(spriteB, spriteC);
       expect(groupAB.displace(spriteC)).to.be.true;
     });
 
-    describe('true if any sprites in group overlap target sprite', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group overlap target sprite', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expect(groupAB.displace(spriteC)).to.be.true;
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expect(groupAB.displace(spriteC)).to.be.true;
       });
     });
 
-    it('does not call callback when not overlapping sprite', function () {
+    it('does not call callback when not overlapping sprite', function() {
       groupAB.displace(spriteC, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each overlap', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each overlap', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.displace(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.displace(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteA, spriteC);
         moveAToB(spriteB, spriteC);
         groupAB.displace(spriteC, testCallback);
@@ -857,86 +857,86 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.displace(group)', function () {
-    it('false if no sprites overlap', function () {
+  describe('group.displace(group)', function() {
+    it('false if no sprites overlap', function() {
       expect(groupAB.displace(groupCD)).to.be.false;
     });
 
-    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+    it('false if no sprite in group AB overlaps any sprite in group CD', function() {
       moveAToB(spriteA, spriteB);
       moveAToB(spriteC, spriteD);
       expect(groupAB.displace(groupCD)).to.be.false;
     });
 
-    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+    it('true if all sprites in group AB overlap all sprites in group CD', function() {
       moveAToB(spriteB, spriteA);
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expect(groupAB.displace(groupCD)).to.be.true;
     });
 
-    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group AB overlap any sprites in group CD', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expect(groupAB.displace(groupCD)).to.be.true;
       });
 
-      it('A overlaps D', function () {
+      it('A overlaps D', function() {
         moveAToB(spriteA, spriteD);
         expect(groupAB.displace(groupCD)).to.be.true;
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expect(groupAB.displace(groupCD)).to.be.true;
       });
 
-      it('B overlaps D', function () {
+      it('B overlaps D', function() {
         moveAToB(spriteB, spriteD);
         expect(groupAB.displace(groupCD)).to.be.true;
       });
     });
 
-    it('group does not overlap self if no sprites within group overlap', function () {
+    it('group does not overlap self if no sprites within group overlap', function() {
       expect(groupAB.displace(groupAB)).to.be.false;
     });
 
-    it('group overlaps self if two different sprites within group overlap', function () {
+    it('group overlaps self if two different sprites within group overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.displace(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       groupAB.displace(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each pair', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each pair', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.displace(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         groupAB.displace(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.displace(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('B-D', function () {
+      it('B-D', function() {
         moveAToB(spriteB, spriteD);
         groupAB.displace(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         groupAB.displace(groupCD, testCallback);
@@ -945,7 +945,7 @@ describe('collisions', function () {
         //       so the second collision (B-C) never happens.
       });
 
-      it('A-B-D', function () {
+      it('A-B-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.displace(groupCD, testCallback);
@@ -954,7 +954,7 @@ describe('collisions', function () {
         //       so the second collision (B-D) never happens.
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.displace(groupCD, testCallback);
@@ -963,7 +963,7 @@ describe('collisions', function () {
           [spriteA.name, spriteD.name]]);
       });
 
-      it('B-C-D', function () {
+      it('B-C-D', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteB);
         groupAB.displace(groupCD, testCallback);
@@ -972,7 +972,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-C, B-D', function () {
+      it('A-C, B-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteB);
         groupAB.displace(groupCD, testCallback);
@@ -981,7 +981,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-D, B-C', function () {
+      it('A-D, B-C', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteA);
         groupAB.displace(groupCD, testCallback);
@@ -990,7 +990,7 @@ describe('collisions', function () {
           [spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C-D', function () {
+      it('A-B-C-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
@@ -1005,53 +1005,53 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.collide(sprite)', function () {
-    it('false if no sprites overlap', function () {
+  describe('group.collide(sprite)', function() {
+    it('false if no sprites overlap', function() {
       expect(groupAB.collide(spriteC)).to.be.false;
     });
 
-    it('false if no sprite in group overlaps target sprite', function () {
+    it('false if no sprite in group overlaps target sprite', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.collide(spriteC)).to.be.false;
     });
 
-    it('true if all sprites in group overlap target sprite', function () {
+    it('true if all sprites in group overlap target sprite', function() {
       moveAToB(spriteA, spriteC);
       moveAToB(spriteB, spriteC);
       expect(groupAB.collide(spriteC)).to.be.true;
     });
 
-    describe('true if any sprites in group overlap target sprite', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group overlap target sprite', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expect(groupAB.collide(spriteC)).to.be.true;
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expect(groupAB.collide(spriteC)).to.be.true;
       });
     });
 
-    it('does not call callback when not overlapping sprite', function () {
+    it('does not call callback when not overlapping sprite', function() {
       groupAB.collide(spriteC, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each overlap', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each overlap', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.collide(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.collide(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteA, spriteC);
         moveAToB(spriteB, spriteC);
         groupAB.collide(spriteC, testCallback);
@@ -1062,86 +1062,86 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.collide(group)', function () {
-    it('false if no sprites overlap', function () {
+  describe('group.collide(group)', function() {
+    it('false if no sprites overlap', function() {
       expect(groupAB.collide(groupCD)).to.be.false;
     });
 
-    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+    it('false if no sprite in group AB overlaps any sprite in group CD', function() {
       moveAToB(spriteA, spriteB);
       moveAToB(spriteC, spriteD);
       expect(groupAB.collide(groupCD)).to.be.false;
     });
 
-    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+    it('true if all sprites in group AB overlap all sprites in group CD', function() {
       moveAToB(spriteB, spriteA);
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expect(groupAB.collide(groupCD)).to.be.true;
     });
 
-    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group AB overlap any sprites in group CD', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expect(groupAB.collide(groupCD)).to.be.true;
       });
 
-      it('A overlaps D', function () {
+      it('A overlaps D', function() {
         moveAToB(spriteA, spriteD);
         expect(groupAB.collide(groupCD)).to.be.true;
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expect(groupAB.collide(groupCD)).to.be.true;
       });
 
-      it('B overlaps D', function () {
+      it('B overlaps D', function() {
         moveAToB(spriteB, spriteD);
         expect(groupAB.collide(groupCD)).to.be.true;
       });
     });
 
-    it('group does not overlap self if no sprites within group overlap', function () {
+    it('group does not overlap self if no sprites within group overlap', function() {
       expect(groupAB.collide(groupAB)).to.be.false;
     });
 
-    it('group overlaps self if two different sprites within group overlap', function () {
+    it('group overlaps self if two different sprites within group overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.collide(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       groupAB.collide(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each pair', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each pair', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.collide(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         groupAB.collide(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.collide(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('B-D', function () {
+      it('B-D', function() {
         moveAToB(spriteB, spriteD);
         groupAB.collide(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         groupAB.collide(groupCD, testCallback);
@@ -1150,7 +1150,7 @@ describe('collisions', function () {
           [spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-D', function () {
+      it('A-B-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.collide(groupCD, testCallback);
@@ -1159,7 +1159,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.collide(groupCD, testCallback);
@@ -1168,7 +1168,7 @@ describe('collisions', function () {
         // Note: due to displacement, only the first collision occurs.
       });
 
-      it('B-C-D', function () {
+      it('B-C-D', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteB);
         groupAB.collide(groupCD, testCallback);
@@ -1177,7 +1177,7 @@ describe('collisions', function () {
         // Note: due to displacement, only the first collision occurs.
       });
 
-      it('A-C, B-D', function () {
+      it('A-C, B-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteB);
         groupAB.collide(groupCD, testCallback);
@@ -1186,7 +1186,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-D, B-C', function () {
+      it('A-D, B-C', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteA);
         groupAB.collide(groupCD, testCallback);
@@ -1195,7 +1195,7 @@ describe('collisions', function () {
           [spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C-D', function () {
+      it('A-B-C-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
@@ -1208,53 +1208,53 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.bounce(sprite)', function () {
-    it('false if no sprites overlap', function () {
+  describe('group.bounce(sprite)', function() {
+    it('false if no sprites overlap', function() {
       expect(groupAB.bounce(spriteC)).to.be.false;
     });
 
-    it('false if no sprite in group overlaps target sprite', function () {
+    it('false if no sprite in group overlaps target sprite', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.bounce(spriteC)).to.be.false;
     });
 
-    it('true if all sprites in group overlap target sprite', function () {
+    it('true if all sprites in group overlap target sprite', function() {
       moveAToB(spriteA, spriteC);
       moveAToB(spriteB, spriteC);
       expect(groupAB.bounce(spriteC)).to.be.true;
     });
 
-    describe('true if any sprites in group overlap target sprite', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group overlap target sprite', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expect(groupAB.bounce(spriteC)).to.be.true;
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expect(groupAB.bounce(spriteC)).to.be.true;
       });
     });
 
-    it('does not call callback when not overlapping sprite', function () {
+    it('does not call callback when not overlapping sprite', function() {
       groupAB.bounce(spriteC, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each overlap', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each overlap', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.bounce(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.bounce(spriteC, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteA, spriteC);
         moveAToB(spriteB, spriteC);
         groupAB.bounce(spriteC, testCallback);
@@ -1265,86 +1265,86 @@ describe('collisions', function () {
     });
   });
 
-  describe('group.bounce(group)', function () {
-    it('false if no sprites overlap', function () {
+  describe('group.bounce(group)', function() {
+    it('false if no sprites overlap', function() {
       expect(groupAB.bounce(groupCD)).to.be.false;
     });
 
-    it('false if no sprite in group AB overlaps any sprite in group CD', function () {
+    it('false if no sprite in group AB overlaps any sprite in group CD', function() {
       moveAToB(spriteA, spriteB);
       moveAToB(spriteC, spriteD);
       expect(groupAB.bounce(groupCD)).to.be.false;
     });
 
-    it('true if all sprites in group AB overlap all sprites in group CD', function () {
+    it('true if all sprites in group AB overlap all sprites in group CD', function() {
       moveAToB(spriteB, spriteA);
       moveAToB(spriteC, spriteA);
       moveAToB(spriteD, spriteA);
       expect(groupAB.bounce(groupCD)).to.be.true;
     });
 
-    describe('true if any sprites in group AB overlap any sprites in group CD', function () {
-      it('A overlaps C', function () {
+    describe('true if any sprites in group AB overlap any sprites in group CD', function() {
+      it('A overlaps C', function() {
         moveAToB(spriteA, spriteC);
         expect(groupAB.bounce(groupCD)).to.be.true;
       });
 
-      it('A overlaps D', function () {
+      it('A overlaps D', function() {
         moveAToB(spriteA, spriteD);
         expect(groupAB.bounce(groupCD)).to.be.true;
       });
 
-      it('B overlaps C', function () {
+      it('B overlaps C', function() {
         moveAToB(spriteB, spriteC);
         expect(groupAB.bounce(groupCD)).to.be.true;
       });
 
-      it('B overlaps D', function () {
+      it('B overlaps D', function() {
         moveAToB(spriteB, spriteD);
         expect(groupAB.bounce(groupCD)).to.be.true;
       });
     });
 
-    it('group does not overlap self if no sprites within group overlap', function () {
+    it('group does not overlap self if no sprites within group overlap', function() {
       expect(groupAB.bounce(groupAB)).to.be.false;
     });
 
-    it('group overlaps self if two different sprites within group overlap', function () {
+    it('group overlaps self if two different sprites within group overlap', function() {
       moveAToB(spriteA, spriteB);
       expect(groupAB.bounce(groupAB)).to.be.true;
     });
 
-    it('does not call callback when not overlapping any sprites', function () {
+    it('does not call callback when not overlapping any sprites', function() {
       groupAB.bounce(groupCD, testCallback);
       expect(callCount).to.equal(0);
     });
 
-    describe('passes collider and collidee to callback for each pair', function () {
-      it('A-C', function () {
+    describe('passes collider and collidee to callback for each pair', function() {
+      it('A-C', function() {
         moveAToB(spriteA, spriteC);
         groupAB.bounce(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteC.name]]);
       });
 
-      it('A-D', function () {
+      it('A-D', function() {
         moveAToB(spriteA, spriteD);
         groupAB.bounce(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteA.name, spriteD.name]]);
       });
 
-      it('B-C', function () {
+      it('B-C', function() {
         moveAToB(spriteB, spriteC);
         groupAB.bounce(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteC.name]]);
       });
 
-      it('B-D', function () {
+      it('B-D', function() {
         moveAToB(spriteB, spriteD);
         groupAB.bounce(groupCD, testCallback);
         expect(pairs).to.deep.equal([[spriteB.name, spriteD.name]]);
       });
 
-      it('A-B-C', function () {
+      it('A-B-C', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         groupAB.bounce(groupCD, testCallback);
@@ -1353,7 +1353,7 @@ describe('collisions', function () {
           [spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-D', function () {
+      it('A-B-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.bounce(groupCD, testCallback);
@@ -1362,7 +1362,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-C-D', function () {
+      it('A-C-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);
         groupAB.bounce(groupCD, testCallback);
@@ -1371,7 +1371,7 @@ describe('collisions', function () {
         // Note: due to displacement, only the first collision occurs.
       });
 
-      it('B-C-D', function () {
+      it('B-C-D', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteB);
         groupAB.bounce(groupCD, testCallback);
@@ -1380,7 +1380,7 @@ describe('collisions', function () {
         // Note: due to displacement, only the first collision occurs.
       });
 
-      it('A-C, B-D', function () {
+      it('A-C, B-D', function() {
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteB);
         groupAB.bounce(groupCD, testCallback);
@@ -1389,7 +1389,7 @@ describe('collisions', function () {
           [spriteB.name, spriteD.name]]);
       });
 
-      it('A-D, B-C', function () {
+      it('A-D, B-C', function() {
         moveAToB(spriteC, spriteB);
         moveAToB(spriteD, spriteA);
         groupAB.bounce(groupCD, testCallback);
@@ -1398,7 +1398,7 @@ describe('collisions', function () {
           [spriteB.name, spriteC.name]]);
       });
 
-      it('A-B-C-D', function () {
+      it('A-B-C-D', function() {
         moveAToB(spriteB, spriteA);
         moveAToB(spriteC, spriteA);
         moveAToB(spriteD, spriteA);

--- a/test/unit/examples.js
+++ b/test/unit/examples.js
@@ -1,8 +1,8 @@
-describe('Example sketches', function () {
+describe('Example sketches', function() {
   var FRAMES_TO_DRAW = 3;
 
   var iframe;
-  var examples = (function findExamples () {
+  var examples = (function findExamples() {
     var FILENAME_RE = /index\.html\?fileName=([A-Za-z0-9_.]+)/g;
     var examples = [];
     var req = new XMLHttpRequest();
@@ -10,7 +10,7 @@ describe('Example sketches', function () {
     req.open('GET', '../examples/index.html', false);
     req.send(null);
 
-    req.responseText.replace(FILENAME_RE, function (_, fileName) {
+    req.responseText.replace(FILENAME_RE, function(_, fileName) {
       examples.push(fileName);
     });
 
@@ -19,11 +19,11 @@ describe('Example sketches', function () {
 
   // The following function's source code is converted to a string
   // and evaluated in an iframe; it is NOT executed directly!
-  var iframeScript = function (parentWindowCbName, framesToDraw) {
+  var iframeScript = function(parentWindowCbName, framesToDraw) {
     var framesDrawn = 0;
     var done = window.parent[parentWindowCbName];
 
-    window.onerror = function (msg, source, lineno, colno, error) {
+    window.onerror = function(msg, source, lineno, colno, error) {
       if (!error) {
         // Some browsers, like PhantomJS, don't pass an error argument.
         return done(new Error(msg + ' @ ' + source + ':' + lineno));
@@ -31,14 +31,14 @@ describe('Example sketches', function () {
       done(error);
     };
 
-    p5.prototype.registerMethod('post', function () {
+    p5.prototype.registerMethod('post', function() {
       if (++framesDrawn === framesToDraw) {
         done();
       }
     });
   }.toString();
 
-  beforeEach(function () {
+  beforeEach(function() {
     iframe = document.createElement('iframe');
     document.body.appendChild(iframe);
     iframe.style.visibility = 'hidden';
@@ -46,13 +46,13 @@ describe('Example sketches', function () {
     iframe.style.height = '480px';
   });
 
-  afterEach(function () {
+  afterEach(function() {
     iframe.parentNode.removeChild(iframe);
   });
 
-  examples.forEach(function (fileName) {
+  examples.forEach(function(fileName) {
     var testName = fileName + ' runs for ' + FRAMES_TO_DRAW + ' frames';
-    it(testName, function (done) {
+    it(testName, function(done) {
       var windowCbName = 'example_' + fileName.slice(0, -3) + '_done';
       var iframeScriptArgs = [
         windowCbName,

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -1,21 +1,21 @@
-describe('Group', function () {
+describe('Group', function() {
   var pInst, group;
 
-  beforeEach(function () {
-    pInst = new p5(function () {});
+  beforeEach(function() {
+    pInst = new p5(function() {});
     group = new pInst.Group();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     pInst.remove();
   });
 
-  it('is an array', function () {
+  it('is an array', function() {
     expect(Array.isArray(group)).to.be.true;
   });
 
-  describe('add()', function () {
-    it('adds a sprite to the group', function () {
+  describe('add()', function() {
+    it('adds a sprite to the group', function() {
       var sprite = pInst.createSprite();
       group.add(sprite);
       expect(group).to.include(sprite);
@@ -23,13 +23,13 @@ describe('Group', function () {
       expect(group.contains(sprite)).to.be.true;
     });
 
-    it('gives the sprite a reference to itself', function () {
+    it('gives the sprite a reference to itself', function() {
       var sprite = pInst.createSprite();
       group.add(sprite);
       expect(sprite.groups).to.include(group);
     });
 
-    it('lets you add different sprites to the group', function () {
+    it('lets you add different sprites to the group', function() {
       var sprite1 = pInst.createSprite();
       var sprite2 = pInst.createSprite();
       group.add(sprite1);
@@ -37,7 +37,7 @@ describe('Group', function () {
       expect(group.length).to.equal(2);
     });
 
-    it('ignores double addition of a unique sprite', function () {
+    it('ignores double addition of a unique sprite', function() {
       var sprite = pInst.createSprite();
       group.add(sprite);
       group.add(sprite);
@@ -46,7 +46,7 @@ describe('Group', function () {
       expect(group[1]).to.be.undefined;
     });
 
-    it('throws if passed something besides a sprite', function () {
+    it('throws if passed something besides a sprite', function() {
       [
         null,
         undefined,
@@ -55,16 +55,16 @@ describe('Group', function () {
         [],
         {},
         new Error('error')
-      ].forEach(function (item) {
-        expect(function () {
+      ].forEach(function(item) {
+        expect(function() {
           group.add(item);
         }).throws('Error: you can only add sprites to a group');
       });
     });
   });
 
-  describe('remove()', function () {
-    it('removes a sprite from the group', function () {
+  describe('remove()', function() {
+    it('removes a sprite from the group', function() {
       var sprite1 = pInst.createSprite();
       var sprite2 = pInst.createSprite();
       group.add(sprite1);
@@ -78,7 +78,7 @@ describe('Group', function () {
       expect(group.contains(sprite2)).to.be.true;
     });
 
-    it('removes the sprite\'s reference to itself', function () {
+    it('removes the sprite\'s reference to itself', function() {
       var sprite = pInst.createSprite();
       group.add(sprite);
       expect(sprite.groups).to.include(group);
@@ -86,7 +86,7 @@ describe('Group', function () {
       expect(sprite.groups).to.not.include(group);
     });
 
-    it('returns false if the sprite is not a member of the group', function () {
+    it('returns false if the sprite is not a member of the group', function() {
       var sprite1 = pInst.createSprite();
       var sprite2 = pInst.createSprite();
       group.add(sprite1);
@@ -97,7 +97,7 @@ describe('Group', function () {
       expect(group.length).to.equal(1);
     });
 
-    it('removes all copies of a sprite if more than one happen to be present', function () {
+    it('removes all copies of a sprite if more than one happen to be present', function() {
       // This shouldn't happen when using a group properly, but just in case let's
       // make sure we clean up properly.
       var sprite = pInst.createSprite();
@@ -111,7 +111,7 @@ describe('Group', function () {
       expect(group.length).to.equal(0);
     });
 
-    it('throws if passed something besides a sprite', function () {
+    it('throws if passed something besides a sprite', function() {
       [
         null,
         undefined,
@@ -120,16 +120,16 @@ describe('Group', function () {
         [],
         {},
         new Error('error')
-      ].forEach(function (item) {
-        expect(function () {
+      ].forEach(function(item) {
+        expect(function() {
           group.remove(item);
         }).throws('Error: you can only remove sprites from a group');
       });
     });
   });
 
-  describe('removeSprites()', function () {
-    it('should remove all sprites', function () {
+  describe('removeSprites()', function() {
+    it('should remove all sprites', function() {
       expect(group.size()).to.equal(0);
       expect(pInst.allSprites.size()).to.equal(0);
 

--- a/test/unit/input.js
+++ b/test/unit/input.js
@@ -1,40 +1,40 @@
-describe('Input', function () {
+describe('Input', function() {
   var myp5;
   var LEFT_ARROW, LEFT;
 
-  beforeEach(function () {
-    myp5 = new p5(function () {});
+  beforeEach(function() {
+    myp5 = new p5(function() {});
     LEFT_ARROW = myp5.LEFT_ARROW;
     LEFT = myp5.LEFT;
   });
 
-  afterEach(function () {
+  afterEach(function() {
     myp5.remove();
   });
 
-  function mouseup (which) {
+  function mouseup(which) {
     myp5._setProperty('mouseButton', which);
     myp5._setProperty('mouseIsPressed', false);
   }
 
-  function mousedown (which) {
+  function mousedown(which) {
     myp5._setProperty('mouseButton', which);
     myp5._setProperty('mouseIsPressed', true);
   }
 
-  function keydown (which) {
+  function keydown(which) {
     myp5._onkeydown({which: which});
   }
 
-  function keyup (which) {
+  function keyup(which) {
     myp5._onkeyup({which: which});
   }
 
-  function nextFrame () {
+  function nextFrame() {
     myp5.readPresses();
   }
 
-  it('reports mouseUp() properly', function () {
+  it('reports mouseUp() properly', function() {
     mousedown(LEFT);
     nextFrame();
 
@@ -52,7 +52,7 @@ describe('Input', function () {
     expect(myp5.mouseUp(LEFT)).to.be.true;
   });
 
-  it('reports mouseDown() properly', function () {
+  it('reports mouseDown() properly', function() {
     mouseup(LEFT);
     nextFrame();
 
@@ -70,7 +70,7 @@ describe('Input', function () {
     expect(myp5.mouseDown(LEFT)).to.be.true;
   });
 
-  it('reports mouseWentDown() properly', function () {
+  it('reports mouseWentDown() properly', function() {
     mouseup(LEFT);
     nextFrame();
 
@@ -86,7 +86,7 @@ describe('Input', function () {
     expect(myp5.mouseWentDown(LEFT)).to.be.false;
   });
 
-  it('reports mouseWentUp() properly', function () {
+  it('reports mouseWentUp() properly', function() {
     mousedown(LEFT);
     nextFrame();
 
@@ -98,7 +98,7 @@ describe('Input', function () {
     expect(myp5.mouseWentUp(LEFT)).to.be.true;
   });
 
-  it('reports keyDown() properly', function () {
+  it('reports keyDown() properly', function() {
     keyup(LEFT_ARROW);
     nextFrame();
 
@@ -116,7 +116,7 @@ describe('Input', function () {
     expect(myp5.keyDown(LEFT_ARROW)).to.be.true;
   });
 
-  it('reports keyWentDown() properly', function () {
+  it('reports keyWentDown() properly', function() {
     keyup(LEFT_ARROW);
     nextFrame();
 
@@ -132,7 +132,7 @@ describe('Input', function () {
     expect(myp5.keyWentDown(LEFT_ARROW)).to.be.false;
   });
 
-  it('reports keyWentUp() properly', function () {
+  it('reports keyWentUp() properly', function() {
     keydown(LEFT_ARROW);
     nextFrame();
 

--- a/test/unit/keycodes.js
+++ b/test/unit/keycodes.js
@@ -1,9 +1,9 @@
-describe('_keyCodeFromAlias', function () {
+describe('_keyCodeFromAlias', function() {
   var pInst, _warn, _keyCodeFromAlias;
   var KEY = p5.prototype.KEY;
 
-  beforeEach(function () {
-    pInst = new p5(function () {});
+  beforeEach(function() {
+    pInst = new p5(function() {});
     _keyCodeFromAlias = pInst._keyCodeFromAlias.bind(pInst);
 
     // Stub p5.prototype._warn to hide console output during tests
@@ -11,14 +11,14 @@ describe('_keyCodeFromAlias', function () {
     _warn = sinon.stub(p5.prototype, '_warn');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     // Restore original p5.prototype._warn so we don't affect other tests.
     _warn.restore();
     pInst.remove();
   });
 
-  describe('key aliases', function () {
-    it('maps every alias to a numeric keycode', function () {
+  describe('key aliases', function() {
+    it('maps every alias to a numeric keycode', function() {
       for (var alias in KEY) {
         if (KEY.hasOwnProperty(alias)) {
           expect(typeof _keyCodeFromAlias(alias)).to.equal('number');
@@ -26,7 +26,7 @@ describe('_keyCodeFromAlias', function () {
       }
     });
 
-    it('is case-insensitive', function () {
+    it('is case-insensitive', function() {
       var upperCaseAlias, lowerCaseAlias, randomCaseAlias;
       for (var alias in KEY) {
         if (KEY.hasOwnProperty(alias)) {
@@ -34,7 +34,7 @@ describe('_keyCodeFromAlias', function () {
           lowerCaseAlias = alias.toLowerCase();
           randomCaseAlias = alias
             .split('')
-            .map(function (char) {
+            .map(function(char) {
               if (Math.random() < 0.5) {
                 return char.toUpperCase();
               } else {
@@ -50,7 +50,7 @@ describe('_keyCodeFromAlias', function () {
       }
     });
 
-    it('does not warn when looking up a regular alias', function () {
+    it('does not warn when looking up a regular alias', function() {
       for (var alias in KEY) {
         if (KEY.hasOwnProperty(alias)) {
           _keyCodeFromAlias(alias);
@@ -59,19 +59,19 @@ describe('_keyCodeFromAlias', function () {
       }
     });
 
-    it('maps MINUS to 109', function () {
+    it('maps MINUS to 109', function() {
       expect(_keyCodeFromAlias('MINUS')).to.equal(109);
     });
 
-    it('maps COMMA to 188', function () {
+    it('maps COMMA to 188', function() {
       expect(_keyCodeFromAlias('COMMA')).to.equal(188);
     });
   });
 
-  describe('deprecated aliases', function () {
+  describe('deprecated aliases', function() {
     var KEY_DEPRECATIONS = p5.prototype.KEY_DEPRECATIONS;
 
-    it('maps every deprecated alias to a valid key alias', function () {
+    it('maps every deprecated alias to a valid key alias', function() {
       for (var alias in KEY_DEPRECATIONS) {
         if (KEY_DEPRECATIONS.hasOwnProperty(alias)) {
           expect(KEY).to.include.keys(KEY_DEPRECATIONS[alias]);
@@ -79,7 +79,7 @@ describe('_keyCodeFromAlias', function () {
       }
     });
 
-    it('does not include any deprecated aliases in key aliases', function () {
+    it('does not include any deprecated aliases in key aliases', function() {
       for (var alias in KEY_DEPRECATIONS) {
         if (KEY_DEPRECATIONS.hasOwnProperty(alias)) {
           expect(KEY).to.not.include.keys(alias);
@@ -87,24 +87,24 @@ describe('_keyCodeFromAlias', function () {
       }
     });
 
-    it('aliases \'MINUT\' to \'MINUS\'', function () {
+    it('aliases \'MINUT\' to \'MINUS\'', function() {
       expect(_keyCodeFromAlias('MINUT'))
         .to.equal(_keyCodeFromAlias('MINUS'));
     });
 
-    it('warns when using MINUT', function () {
+    it('warns when using MINUT', function() {
       _keyCodeFromAlias('MINUT');
       expect(_warn.firstCall.args[0])
         .to.equal('Key literal "MINUT" is deprecated and may be removed in a ' +
                   'future version of p5.play. Please use "MINUS" instead.');
     });
 
-    it('aliases \'COMA\' to \'COMMA\'', function () {
+    it('aliases \'COMA\' to \'COMMA\'', function() {
       expect(_keyCodeFromAlias('COMA'))
         .to.equal(_keyCodeFromAlias('COMMA'));
     });
 
-    it('warns when using COMA', function () {
+    it('warns when using COMA', function() {
       _keyCodeFromAlias('COMA');
       expect(_warn.firstCall.args[0])
         .to.equal('Key literal "COMA" is deprecated and may be removed in a ' +

--- a/test/unit/sketch-properties.js
+++ b/test/unit/sketch-properties.js
@@ -1,17 +1,17 @@
-describe('p5 sketch instances', function () {
+describe('p5 sketch instances', function() {
   var pInstA, pInstB;
 
-  beforeEach(function () {
-    pInstA = new p5(function () {});
-    pInstB = new p5(function () {});
+  beforeEach(function() {
+    pInstA = new p5(function() {});
+    pInstB = new p5(function() {});
   });
 
-  afterEach(function () {
+  afterEach(function() {
     pInstA.remove();
     pInstB.remove();
   });
 
-  it('have their own allSprites property', function () {
+  it('have their own allSprites property', function() {
     expect(pInstA.allSprites.length).to.equal(0);
     expect(pInstB.allSprites.length).to.equal(0);
 
@@ -23,7 +23,7 @@ describe('p5 sketch instances', function () {
     expect(pInstB.allSprites.length).to.equal(0);
   });
 
-  it('have their own spriteUpdate property', function () {
+  it('have their own spriteUpdate property', function() {
     expect(pInstA.spriteUpdate).to.be.true;
     expect(pInstB.spriteUpdate).to.be.true;
 

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -1,15 +1,15 @@
-describe('Sprite', function () {
+describe('Sprite', function() {
   var pInst;
 
-  beforeEach(function () {
-    pInst = new p5(function () {});
+  beforeEach(function() {
+    pInst = new p5(function() {});
   });
 
-  afterEach(function () {
+  afterEach(function() {
     pInst.remove();
   });
 
-  it('sets correct coordinate mode for rendering', function () {
+  it('sets correct coordinate mode for rendering', function() {
     // Note: This test reaches into p5's internals somewhat more than usual.
     // It's designed to catch a particular rendering regression reported in
     // issue #48, where certain local constants are initialized incorrectly.
@@ -19,7 +19,7 @@ describe('Sprite', function () {
 
     // Monkeypatch sprite's draw method to inspect coordinate mode at draw-time.
     var sprite = pInst.createSprite();
-    sprite.draw = function () {
+    sprite.draw = function() {
       rectMode = pInst._renderer._rectMode;
       ellipseMode = pInst._renderer._ellipseMode;
       imageMode = pInst._renderer._imageMode;

--- a/test/unit/spritesheet.js
+++ b/test/unit/spritesheet.js
@@ -1,21 +1,21 @@
-describe('SpriteSheet', function () {
+describe('SpriteSheet', function() {
   var pInst;
 
-  beforeEach(function () {
-    pInst = new p5(function () {});
+  beforeEach(function() {
+    pInst = new p5(function() {});
   });
 
-  afterEach(function () {
+  afterEach(function() {
     pInst.remove();
   });
 
-  it('can be instantiated via constructor', function () {
+  it('can be instantiated via constructor', function() {
     var sheet = new pInst.SpriteSheet();
 
     expect(sheet).to.be.an.instanceOf(pInst.SpriteSheet);
   });
 
-  it('can be instantiated via loadSpriteSheet()', function () {
+  it('can be instantiated via loadSpriteSheet()', function() {
     var sheet = pInst.loadSpriteSheet();
 
     expect(sheet).to.be.an.instanceOf(pInst.SpriteSheet);


### PR DESCRIPTION
Require no space between function name and parens for both named and anonymous functions (see [discussion here](https://github.com/molleindustria/p5.play/pull/79/files/639d24dec5dae7f1ab869027627d3b63aec242e2#r58138388)).

Move setting up to root config, since we nearly conform in p5.play.js already.

Autocorrect style.