### PR TITLE
lock rotateToDirection bidirectionally, make angle optional on setSpeed

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -892,7 +892,29 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 0
   */
-  this.rotation = 0;
+  Object.defineProperty(this, 'rotation', {
+    enumerable: true,
+    get: function() {
+      return this.rotation_;
+    },
+    set: function(value) {
+      this.rotation_ = value;
+      if (this.rotateToDirection) {
+        this.setSpeed(this.getSpeed(), value);
+      }
+    }
+  });
+
+  /**
+  * Internal rotation variable (expressed in degrees).
+  * Note: external callers access this through the rotation property above.
+  *
+  * @private
+  * @property rotation_
+  * @type {Number}
+  * @default 0
+  */
+  this.rotation_ = 0;
 
   /**
   * Rotation change in degrees per frame of thevisual element (image or animation)
@@ -906,8 +928,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
 
   /**
-  * Automatically set the rotation of the visual element
-  * (image or animation) to the sprite's movement direction.
+  * Automatically lock the rotation property of the visual element
+  * (image or animation) to the sprite's movement direction and vice versa.
   *
   * @property rotateToDirection
   * @type {Boolean}
@@ -1115,10 +1137,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
       if(this.maxSpeed !== -1)
         this.limitSpeed(this.maxSpeed);
 
-      if(this.rotateToDirection)
-        this.rotation = this.getDirection();
-      else
-        this.rotation += this.rotationSpeed;
+      if(this.rotateToDirection && this.velocity.mag() > 0)
+        this.rotation_ = this.getDirection();
+
+      this.rotation += this.rotationSpeed;
 
       this.position.x += this.velocity.x;
       this.position.y += this.velocity.y;
@@ -1616,13 +1638,25 @@ function Sprite(pInst, _x, _y, _w, _h) {
   /**
   * Set the speed and direction of the sprite.
   * The action overwrites the current velocity.
+  * If direction is not supplied, the current direction is maintained.
+  * If direction is not supplied and there is no current velocity, the current
+  * rotation angle used for the direction.
   *
   * @method setSpeed
-  * @param {Number}  speed Scalar speed to add
-  * @param {Number}  angle Direction in degrees
+  * @param {Number}  speed Scalar speed
+  * @param {Number}  [angle] Direction in degrees
   */
   this.setSpeed = function(speed, angle) {
-    var a = radians(angle);
+    var a;
+    if (typeof angle === 'undefined') {
+      if (this.velocity.x !== 0 || this.velocity.y !== 0) {
+        a = Math.atan2(this.velocity.y, this.velocity.x);
+      } else {
+        a = radians(this.rotation_);
+      }
+    } else {
+      a = radians(angle);
+    }
     this.velocity.x = cos(a)*speed;
     this.velocity.y = sin(a)*speed;
   };

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -895,10 +895,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
   Object.defineProperty(this, 'rotation', {
     enumerable: true,
     get: function() {
-      return this.rotation_;
+      return this._rotation;
     },
     set: function(value) {
-      this.rotation_ = value;
+      this._rotation = value;
       if (this.rotateToDirection) {
         this.setSpeed(this.getSpeed(), value);
       }
@@ -910,11 +910,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * Note: external callers access this through the rotation property above.
   *
   * @private
-  * @property rotation_
+  * @property _rotation
   * @type {Number}
   * @default 0
   */
-  this.rotation_ = 0;
+  this._rotation = 0;
 
   /**
   * Rotation change in degrees per frame of thevisual element (image or animation)
@@ -1138,7 +1138,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
         this.limitSpeed(this.maxSpeed);
 
       if(this.rotateToDirection && this.velocity.mag() > 0)
-        this.rotation_ = this.getDirection();
+        this._rotation = this.getDirection();
 
       this.rotation += this.rotationSpeed;
 
@@ -1652,7 +1652,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       if (this.velocity.x !== 0 || this.velocity.y !== 0) {
         a = Math.atan2(this.velocity.y, this.velocity.x);
       } else {
-        a = radians(this.rotation_);
+        a = radians(this._rotation);
       }
     } else {
       a = radians(angle);


### PR DESCRIPTION
code.org is using p5.play.js as part of a new computer science curriculum. We would like to change the behavior of the Sprite object's `rotateToDirection` property to make it lock the `rotation` property with the `velocity` angle bi-directionally (the current behavior is to ignore the `rotation` property in this mode and continually overwrite it with the angle of the `velocity` vector). This change is accomplished by implementing a custom "setter" for the `rotation` property that updates the `velocity` vector when `rotateToDirection` is `true`. The internal (private) storage for the `rotation` property value is now stored in the `rotation_` property.

In addition, we would like to change the second parameter of the Sprite object's `setSpeed` function (the `angle`) to be optional, so that the speed alone can be changed. (Omitting the `angle` parameter is essentially the same as calling `sprite.setSpeed(<new value>, sprite.getDirection())`, except we have elected to default the `angle` to the `rotation` property when the `velocity` vector is `0,0`). This allows the student to enable `rotateToDirection`, then freely call `setSpeed()` with a `speed` parameter only and set `rotation` to change direction. The sprite can be stopped in this mode by calling `setSpeed(0)` and restarted along the same angle by calling `setSpeed()` with a positive speed value.

The `rotationSpeed` property will now continue to be respected even while in `rotateToDirection` mode. To preserve the previous behavior of always locking the `rotation` property to the `velocity` angle, the `rotation` property should not be modified and the `rotationSpeed` property should be set to zero.