### PR TITLE
Document sprite.depth default value

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -139,6 +139,10 @@ p5.prototype.spriteUpdate = true;
    * A Sprite can have a collider that defines the active area to detect
    * collisions or overlappings with other sprites and mouse interactions.
    *
+   * Sprites created using createSprite (the preferred way) are added to the
+   * allSprites group and given a depth value that puts it in front of all
+   * other sprites.
+   *
    * @method createSprite
    * @param {Number} x Initial x coordinate
    * @param {Number} y Initial y coordinate
@@ -926,7 +930,9 @@ function Sprite(pInst, _x, _y, _w, _h) {
   *
   * @property depth
   * @type {Number}
-  * @default 0
+  * @default One more than the greatest existing sprite depth, when calling
+  *          createSprite().  When calling new Sprite() directly, depth will
+  *          initialize to 0 (not recommended).
   */
   this.depth = 0;
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2602,18 +2602,13 @@ function Group() {
   * @return {Number} The depth of the sprite drawn on the bottom
   */
   array.minDepth = function() {
-    var min;
+    if (array.length === 0) {
+      return 99999;
+    }
 
-    if(array.length === 0)
-      min = 99999;
-    else
-      min = array[0].depth;
-
-    for(var i = 0; i<array.length; i++)
-      if(array[i].depth<min)
-        min = array[i].depth;
-
-    return min;
+    return array.reduce(function(memo, sprite) {
+      return Math.min(memo, sprite.depth);
+    }, Infinity);
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2586,18 +2586,13 @@ function Group() {
   * @return {Number} The depth of the sprite drawn on the top
   */
   array.maxDepth = function() {
-    var max;
+    if (array.length === 0) {
+      return 0;
+    }
 
-    if(array.length === 0)
-      max = 0;
-    else
-      max = array[0].depth;
-
-    for(var i = 0; i<array.length; i++)
-      if(array[i].depth>max)
-        max = array[i].depth;
-
-    return max;
+    return array.reduce(function(memo, sprite) {
+      return Math.max(memo, sprite.depth);
+    }, -Infinity);
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2590,8 +2590,8 @@ function Group() {
       return 0;
     }
 
-    return array.reduce(function(memo, sprite) {
-      return Math.max(memo, sprite.depth);
+    return array.reduce(function(maxDepth, sprite) {
+      return Math.max(maxDepth, sprite.depth);
     }, -Infinity);
   };
 
@@ -2606,8 +2606,8 @@ function Group() {
       return 99999;
     }
 
-    return array.reduce(function(memo, sprite) {
-      return Math.min(memo, sprite.depth);
+    return array.reduce(function(minDepth, sprite) {
+      return Math.min(minDepth, sprite.depth);
     }, Infinity);
   };
 

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -211,4 +211,71 @@ describe('Group', function() {
       expect(group.maxDepth()).to.equal(topSprite.depth);
     });
   });
+
+  describe('minDepth()', function() {
+    it('should be 99999 for an empty group', function() {
+      expect(group.minDepth()).to.equal(99999);
+    });
+
+    it('should be the depth of the sprite in a single-sprite group', function() {
+      var sprite = pInst.createSprite(1, 1);
+      sprite.depth = 99;
+      group.add(sprite);
+      expect(group.minDepth()).to.equal(sprite.depth);
+    });
+
+    it('even when the max sprite depth is greater than 99999', function() {
+      var sprite = pInst.createSprite(1, 1);
+      sprite.depth = Number.MAX_VALUE;
+      expect(sprite.depth).to.be.greaterThan(99999);
+      group.add(sprite);
+      expect(group.minDepth()).to.equal(sprite.depth);
+    });
+
+    it('should be the greatest depth of sprites in the group', function() {
+      var bottomSprite = pInst.createSprite(1, 1);
+      var sprite2 = pInst.createSprite(1, 2);
+      var sprite3 = pInst.createSprite(1, 3);
+
+      bottomSprite.depth = 1;
+      sprite2.depth = 15;
+      sprite3.depth = 101;
+      expect(pInst.allSprites.minDepth()).to.equal(bottomSprite.depth);
+
+      // Regardless of order they are added
+      group.add(sprite3);
+      group.add(bottomSprite);
+      group.add(sprite2);
+      expect(group.minDepth()).to.equal(bottomSprite.depth);
+    });
+
+    it('only considers sprites in the given group', function() {
+      var bottomSprite = pInst.createSprite(1, 1);
+      var sprite2 = pInst.createSprite(1, 2);
+      var sprite3 = pInst.createSprite(1, 3);
+
+      bottomSprite.depth = 1;
+      sprite2.depth = 15;
+      sprite3.depth = 101;
+
+      group.add(sprite3);
+      group.add(sprite2);
+      expect(group.minDepth()).to.equal(sprite2.depth);
+    });
+
+    it('works given negative depths too', function() {
+      var bottomSprite = pInst.createSprite(1, 1);
+      var sprite2 = pInst.createSprite(1, 2);
+      var sprite3 = pInst.createSprite(1, 3);
+
+      bottomSprite.depth = -100;
+      sprite2.depth = -15;
+      sprite3.depth = -50;
+
+      group.add(bottomSprite);
+      group.add(sprite2);
+      group.add(sprite3);
+      expect(group.minDepth()).to.equal(bottomSprite.depth);
+    });
+  });
 });

--- a/test/unit/group.js
+++ b/test/unit/group.js
@@ -145,4 +145,70 @@ describe('Group', function() {
       expect(pInst.allSprites.size()).to.equal(0);
     });
   });
+
+  describe('maxDepth()', function() {
+    it('should be zero for an empty group', function() {
+      expect(group.maxDepth()).to.equal(0);
+    });
+
+    it('should be the depth of the sprite in a single-sprite group', function() {
+      var sprite = pInst.createSprite(1, 1);
+      sprite.depth = 99;
+      group.add(sprite);
+      expect(group.maxDepth()).to.equal(sprite.depth);
+    });
+
+    it('even when the max sprite depth is negative', function() {
+      var sprite = pInst.createSprite(1, 1);
+      sprite.depth = -99;
+      group.add(sprite);
+      expect(group.maxDepth()).to.equal(sprite.depth);
+    });
+
+    it('should be the greatest depth of sprites in the group', function() {
+      var topSprite = pInst.createSprite(1, 1);
+      var sprite2 = pInst.createSprite(1, 2);
+      var sprite3 = pInst.createSprite(1, 3);
+
+      topSprite.depth = 100;
+      sprite2.depth = 15;
+      sprite3.depth = -101;
+      expect(pInst.allSprites.maxDepth()).to.equal(topSprite.depth);
+
+      // Regardless of order they are added
+      group.add(sprite3);
+      group.add(topSprite);
+      group.add(sprite2);
+      expect(group.maxDepth()).to.equal(topSprite.depth);
+    });
+
+    it('only considers sprites in the given group', function() {
+      var topSprite = pInst.createSprite(1, 1);
+      var sprite2 = pInst.createSprite(1, 2);
+      var sprite3 = pInst.createSprite(1, 3);
+
+      topSprite.depth = 100;
+      sprite2.depth = 15;
+      sprite3.depth = -101;
+
+      group.add(sprite3);
+      group.add(sprite2);
+      expect(group.maxDepth()).to.equal(sprite2.depth);
+    });
+
+    it('works given negative depths too', function() {
+      var topSprite = pInst.createSprite(1, 1);
+      var sprite2 = pInst.createSprite(1, 2);
+      var sprite3 = pInst.createSprite(1, 3);
+
+      topSprite.depth = -12;
+      sprite2.depth = -15;
+      sprite3.depth = -101;
+
+      group.add(topSprite);
+      group.add(sprite2);
+      group.add(sprite3);
+      expect(group.maxDepth()).to.equal(topSprite.depth);
+    });
+  });
 });


### PR DESCRIPTION
_Fixes #75_

Expands documentation for sprite.depth.

While I was at it, I couldn't resist cleaning up the implementations of `Group.maxDepth` and `Group.minDepth`, which meant writing corresponding tests to pin the existing behavior.  These tests reveal a few weird edge cases around existing behavior, but I'm not changing it in this PR, just pinning it.  We can change later if we want.

Weird behaviors:
* Default value of `maxDepth` is 0 when a group is empty, but a group can contain sprites with only negative depths which will give a `maxDepth` less than 0.  A better default might be `-Infinity`.
* Stranger: Default value of `minDepth` is 99,999 when a group is empty, but a group can contain sprites with only depths greater than 99,999 in which case `minDepth` is also greater.  A better default might be `Infinity`.