### PR TITLE
Don't allow ESLint >=2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A p5.js library for the creation of games and playthings.",
   "dependencies": {},
   "devDependencies": {
-    "eslint": "^2.5.3",
+    "eslint": ">=2.5.3 <2.10.0",
     "http-server": "^0.9.0",
     "mocha-phantomjs": "^4.0.1",
     "yuidocjs": "^0.10.0"


### PR DESCRIPTION
A [regression in ESLint](https://github.com/eslint/eslint/issues/6173) causes false positives from the max-statements-per-line rule.  So far versions 2.10.0-2.10.2 are affected.

[The fix](https://github.com/eslint/eslint/pull/6192) has been merged and seems likely to land in 2.10.3.  Once that happens we should update our depedency to allow >= the fixed version.