### PR TITLE
lock rotateToDirection bidirectionally, make angle optional on setSpeed (reopened)

### DIFF
--- a/examples/lib/p5.js
+++ b/examples/lib/p5.js
@@ -1,4 +1,4 @@
-/*! p5.js v0.4.24 April 25, 2016 */
+/*! p5.js v0.4.21 January 22, 2016 */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.p5 = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 
 },{}],2:[function(_dereq_,module,exports){
@@ -5589,7 +5589,7 @@ p5.prototype.plane = function(width, height){
 };
 
 /**
- * Draw a sphere with given radius
+ * Draw a sphere with given raduis
  * @method sphere
  * @param  {Number} radius            radius of circle
  * @param  {Number} [detail]          number of segments,
@@ -5646,21 +5646,20 @@ p5.prototype.sphere = function(radius, detail){
 };
 
 /**
- * Draw an ellipsoid with given radius
+ * Draw an ellipsoid with given raduis
  * @method ellipsoid
  * @param  {Number} radiusx           xradius of circle
  * @param  {Number} radiusy           yradius of circle
  * @param  {Number} radiusz           zradius of circle
- * @param  {Number} [detail]          Number of segments.
- *                                    The more segments, the smoother the
- *                                    geometry (default is 24). Avoid detail
- *                                    number above 150. It may crash the
- *                                    browser.
+ * @param  {Number} [detail]          number of segments,
+ *                                    the more segments the smoother geometry
+ *                                    default is 24. Avoid detail number above
+ *                                    150. It may crash the browser.
  * @return {p5}                       the p5 object
  * @example
  * <div>
  * <code>
- * // draw an ellipsoid with radius 200, 300 and 400
+ * // draw an ellipsoid with radius 200, 300 and 400 .
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
  * }
@@ -5723,7 +5722,7 @@ p5.prototype.ellipsoid = function(radiusx, radiusy, radiusz, detail){
  * @example
  * <div>
  * <code>
- * //draw a spinning cylinder with radius 200 and height 200
+ * //draw a spining sylinder with radius 200 and height 200
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
  * }
@@ -5819,7 +5818,7 @@ p5.prototype.cylinder = function(radius, height, detail){
  * @example
  * <div>
  * <code>
- * //draw a spinning cone with radius 200 and height 200
+ * //draw a spining cone with radius 200 and height 200
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
  * }
@@ -5892,7 +5891,7 @@ p5.prototype.cone = function(radius, height, detail){
  * @example
  * <div>
  * <code>
- * //draw a spinning torus with radius 200 and tube radius 60
+ * //draw a spining torus with radius 200 and tube radius 60
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
  * }
@@ -5951,7 +5950,7 @@ p5.prototype.torus = function(radius, tubeRadius, detail){
  * @example
  * <div>
  * <code>
- * //draw a spinning box with width, height and depth 200
+ * //draw a spining box with width, height and depth 200
  * function setup(){
  *   createCanvas(100, 100, WEBGL);
  * }
@@ -6043,7 +6042,6 @@ p5.prototype.box = function(width, height, depth){
 };
 
 module.exports = p5;
-
 },{"../core/core":48,"./p5.Geometry3D":34}],29:[function(_dereq_,module,exports){
 /**
  * @module Lights, Camera
@@ -6329,7 +6327,7 @@ p5.Renderer3D.prototype.strokeWeight = function() {
 //////////////////////////////////////////////
 
 p5.Renderer3D.prototype.fill = function(r, g, b, a) {
-  var color = this._pInst.color.apply(this, arguments);
+  var color = this._pInst.color.apply(this._pInst, arguments);
   var colorNormalized = color._array;
   this.curColor = colorNormalized;
   this.drawMode = 'fill';
@@ -6337,7 +6335,7 @@ p5.Renderer3D.prototype.fill = function(r, g, b, a) {
 };
 
 p5.Renderer3D.prototype.stroke = function(r, g, b, a) {
-  var color = this._pInst.color.apply(this, arguments);
+  var color = this._pInst.color.apply(this._pInst, arguments);
   var colorNormalized = color._array;
   this.curColor = colorNormalized;
   this.drawMode = 'stroke';
@@ -7859,7 +7857,7 @@ p5.Matrix.prototype.ortho = function(left,right,bottom,top,near,far){
 //];
 
 module.exports = p5.Matrix;
-},{"../core/constants":47,"../core/core":48,"../math/polargeometry":78}],36:[function(_dereq_,module,exports){
+},{"../core/constants":47,"../core/core":48,"../math/polargeometry":77}],36:[function(_dereq_,module,exports){
 'use strict';
 
 var p5 = _dereq_('../core/core');
@@ -8418,7 +8416,6 @@ _dereq_('./image/p5.Image');
 _dereq_('./math/p5.Vector');
 _dereq_('./io/p5.TableRow');
 _dereq_('./io/p5.Table');
-_dereq_('./io/p5.XML');
 
 _dereq_('./color/creating_reading');
 _dereq_('./color/setting');
@@ -8494,7 +8491,7 @@ if (document.readyState === 'complete') {
 }
 
 module.exports = p5;
-},{"./3d/3d_primitives":28,"./3d/camera":29,"./3d/immediateMode3D":30,"./3d/interaction":31,"./3d/light":32,"./3d/material":33,"./3d/p5.Geometry3D":34,"./3d/p5.Matrix":35,"./3d/p5.Renderer3D":36,"./3d/retainedMode3D":37,"./3d/shader":38,"./color/creating_reading":41,"./color/p5.Color":42,"./color/setting":43,"./core/2d_primitives":44,"./core/attributes":45,"./core/constants":47,"./core/core":48,"./core/curves":49,"./core/environment":50,"./core/p5.Element":52,"./core/p5.Graphics":53,"./core/p5.Renderer2D":55,"./core/rendering":56,"./core/structure":58,"./core/transform":59,"./core/vertex":60,"./events/acceleration":61,"./events/keyboard":62,"./events/mouse":63,"./events/touch":64,"./image/image":66,"./image/loading_displaying":67,"./image/p5.Image":68,"./image/pixels":69,"./io/files":70,"./io/p5.Table":71,"./io/p5.TableRow":72,"./io/p5.XML":73,"./math/calculation":74,"./math/math":75,"./math/noise":76,"./math/p5.Vector":77,"./math/random":79,"./math/trigonometry":80,"./typography/attributes":81,"./typography/loading_displaying":82,"./typography/p5.Font":83,"./utilities/array_functions":84,"./utilities/conversion":85,"./utilities/string_functions":86,"./utilities/time_date":87}],40:[function(_dereq_,module,exports){
+},{"./3d/3d_primitives":28,"./3d/camera":29,"./3d/immediateMode3D":30,"./3d/interaction":31,"./3d/light":32,"./3d/material":33,"./3d/p5.Geometry3D":34,"./3d/p5.Matrix":35,"./3d/p5.Renderer3D":36,"./3d/retainedMode3D":37,"./3d/shader":38,"./color/creating_reading":41,"./color/p5.Color":42,"./color/setting":43,"./core/2d_primitives":44,"./core/attributes":45,"./core/constants":47,"./core/core":48,"./core/curves":49,"./core/environment":50,"./core/p5.Element":52,"./core/p5.Graphics":53,"./core/p5.Renderer2D":55,"./core/rendering":56,"./core/structure":58,"./core/transform":59,"./core/vertex":60,"./events/acceleration":61,"./events/keyboard":62,"./events/mouse":63,"./events/touch":64,"./image/image":66,"./image/loading_displaying":67,"./image/p5.Image":68,"./image/pixels":69,"./io/files":70,"./io/p5.Table":71,"./io/p5.TableRow":72,"./math/calculation":73,"./math/math":74,"./math/noise":75,"./math/p5.Vector":76,"./math/random":78,"./math/trigonometry":79,"./typography/attributes":80,"./typography/loading_displaying":81,"./typography/p5.Font":82,"./utilities/array_functions":83,"./utilities/conversion":84,"./utilities/string_functions":85,"./utilities/time_date":86}],40:[function(_dereq_,module,exports){
 /**
  * module Conversion
  * submodule Color Conversion
@@ -8859,8 +8856,13 @@ p5.prototype.brightness = function(c) {
  * Colors are stored as Numbers or Arrays.
  *
  * @method color
- * @param  {Number|String} gray    number specifying value between white
- *                                 and black.
+ * @param  {Number|String} v1      gray value or red or hue value relative to
+ *                                 the current color range, or a color string
+ * @param  {Number}        [v2]    gray value or green or saturation value
+ *                                 relative to the current color range (or
+ *                                 alpha value if first param is gray value)
+ * @param  {Number}        [v3]    gray value or blue or brightness value
+ *                                 relative to the current color range
  * @param  {Number}        [alpha] alpha value relative to current color range
  * @return {Array}                 resulting color
  *
@@ -8987,33 +8989,13 @@ p5.prototype.brightness = function(c) {
  * </code>
  * </div>
  */
-
-/**
- * @method color
- * @param  {Number|String} v1      red or hue value relative to
- *                                 the current color range, or a color string
- * @param  {Number}        v2      green or saturation value
- *                                 relative to the current color range
- * @param  {Number}        v3      blue or brightness value
- *                                 relative to the current color range
- * @param  {Number}        [alpha]
- */
-
 p5.prototype.color = function() {
   if (arguments[0] instanceof p5.Color) {
     return arguments[0];  // Do nothing if argument is already a color object.
   } else if (arguments[0] instanceof Array) {
-    if (this instanceof p5.Renderer) {
-      return new p5.Color(this, arguments[0]);
-    } else {
-      return new p5.Color(this._renderer, arguments[0]);
-    }
+    return new p5.Color(this, arguments[0]);
   } else {
-    if (this instanceof p5.Renderer) {
-      return new p5.Color(this, arguments);
-    } else {
-      return new p5.Color(this._renderer, arguments);
-    }
+    return new p5.Color(this, arguments);
   }
 };
 
@@ -9289,11 +9271,11 @@ var color_conversion = _dereq_('./color_conversion');
  * @class p5.Color
  * @constructor
  */
-p5.Color = function(renderer, vals) {
+p5.Color = function(pInst, vals) {
 
   // Record color mode and maxes at time of construction.
-  this.mode = renderer._colorMode;
-  this.maxes = renderer._colorMaxes;
+  this.mode = pInst._renderer._colorMode;
+  this.maxes = pInst._renderer._colorMaxes;
 
   // Calculate normalized RGBA values.
   if (this.mode !== constants.RGB &&
@@ -9301,7 +9283,7 @@ p5.Color = function(renderer, vals) {
       this.mode !== constants.HSB) {
     throw new Error(this.mode + ' is an invalid colorMode.');
   } else {
-    this._array = p5.Color._parseInputs.apply(renderer, vals);
+    this._array = p5.Color._parseInputs.apply(pInst, vals);
   }
 
   // Expose closest screen color.
@@ -9686,8 +9668,8 @@ var colorPatterns = {
  */
 p5.Color._parseInputs = function() {
   var numArgs = arguments.length;
-  var mode = this._colorMode;
-  var maxes = this._colorMaxes;
+  var mode = this._renderer._colorMode;
+  var maxes = this._renderer._colorMaxes;
   var results = [];
 
   if (numArgs >= 3) {  // Argument is a list of component values.
@@ -9883,8 +9865,17 @@ _dereq_('./p5.Color');
  * the first frame of animation or if the background need only be set once.
  *
  * @method background
- * @param {p5.Color} color     any value created by the color() function
- * @param {Number} [a]         opacity of the background
+ * @param {Number|String|p5.Color|p5.Image} v1   gray value, red or hue value
+ *                                               (depending on the current
+ *                                               color mode), color string,
+ *                                               p5.Color, or p5.Image
+ * @param {Number}                          [v2] green or saturation value
+ *                                               (depending on the current
+ *                                               color mode)
+ * @param {Number}                          [v3] blue or brightness value
+ *                                               (depending on the current
+ *                                               color mode)
+ * @param {Number}                          [a]  opacity of the background
  *
  * @example
  * <div>
@@ -9964,39 +9955,6 @@ _dereq_('./p5.Color');
  * background(color(0, 0, 255));
  * </code>
  * </div>
- */
-
-/**
- * @method background
- * @param {String} colorstring color string, possible formats include: integer
- *                         rgb() or rgba(), percentage rgb() or rgba(),
- *                         3-digit hex, 6-digit hex
- * @param {Number} [a]
- */
-
-/**
- * @method background
- * @param {Number} gray   specifies a value between white and black
- * @param {Number} [a]
- */
-
-/**
- * @method background
- * @param {Number} v1     red or hue value (depending on the current color
- *                        mode)
- * @param {Number} v2     green or saturation value (depending on the current
- *                        color mode)
- * @param {Number} v3     blue or brightness value (depending on the current
- *                        color mode)
- * @param {Number} [a]
- */
-
-/**
- * @method background
- * @param {p5.Image} image     image created with loadImage() or createImage(),
- *                             to set as background
- *                             (must be same size as the sketch window)
- * @param {Number} [a]
  */
 p5.prototype.background = function() {
   if (arguments[0] instanceof p5.Image) {
@@ -10533,11 +10491,6 @@ p5.prototype.arc = function(x, y, w, h, start, stop, mode) {
   start %= constants.TWO_PI;
   stop %= constants.TWO_PI;
 
-  // account for full circle
-  if (stop === start) {
-    stop += constants.TWO_PI;
-  }
-
   // Adjust angles to counter linear scaling.
   if (start <= constants.HALF_PI) {
     start = Math.atan(w / h * Math.tan(start));
@@ -10756,14 +10709,14 @@ p5.prototype.point = function() {
  * clockwise or counter-clockwise around the defined shape.
  *
  * @method quad
- * @param {Number} x1 the x-coordinate of the first point
- * @param {Number} y1 the y-coordinate of the first point
- * @param {Number} x2 the x-coordinate of the second point
- * @param {Number} y2 the y-coordinate of the second point
- * @param {Number} x3 the x-coordinate of the third point
- * @param {Number} y3 the y-coordinate of the third point
- * @param {Number} x4 the x-coordinate of the fourth point
- * @param {Number} y4 the y-coordinate of the fourth point
+ * @param {type} x1 the x-coordinate of the first point
+ * @param {type} y1 the y-coordinate of the first point
+ * @param {type} x2 the x-coordinate of the second point
+ * @param {type} y2 the y-coordinate of the second point
+ * @param {type} x3 the x-coordinate of the third point
+ * @param {type} y3 the y-coordinate of the third point
+ * @param {type} x4 the x-coordinate of the fourth point
+ * @param {type} y4 the y-coordinate of the fourth point
  * @return {p5}     the p5 object
  * @example
  * <div>
@@ -10869,7 +10822,7 @@ p5.prototype.quad = function() {
 * <code>
 * // Draw a rectangle with rounded corners having the following radii:
 * // top-left = 20, top-right = 15, bottom-right = 10, bottom-left = 5.
-* rect(30, 20, 55, 55, 20, 15, 10, 5);
+* rect(30, 20, 55, 55, 20, 15, 10, 5)
 * </code>
 * </div>
 */
@@ -11613,9 +11566,8 @@ var p5 = function(sketch, node, sync) {
   /**
    * Called directly after setup(), the draw() function continuously executes
    * the lines of code contained inside its block until the program is stopped
-   * or noLoop() is called. Note if noLoop() is called in setup(), draw() will
-   * still be executed once before stopping. draw() is called automatically and
-   * should never be called explicitly.
+   * or noLoop() is called. draw() is called automatically and should never be
+   * called explicitly.
    * <br><br>
    * It should always be controlled with noLoop(), redraw() and loop(). After
    * noLoop() stops the code in draw() from executing, redraw() causes the
@@ -11687,15 +11639,17 @@ var p5 = function(sketch, node, sync) {
     'blur': null
   };
 
-  this._events.wheel = null;
-  this._loadingScreenId = 'p5_loading';
-
   if (window.DeviceOrientationEvent) {
     this._events.deviceorientation = null;
   }
   if (window.DeviceMotionEvent && !window._isNodeWebkit) {
     this._events.devicemotion = null;
   }
+
+  this._events.wheel = null;
+
+
+  this._loadingScreenId = 'p5_loading';
 
   this._start = function () {
     // Find node if id given
@@ -11806,14 +11760,17 @@ var p5 = function(sketch, node, sync) {
       context.setup();
     }
 
+    // // unhide hidden canvas that was created
+    // this.canvas.style.visibility = '';
+    // this.canvas.className = this.canvas.className.replace('p5_hidden', '');
+
     // unhide any hidden canvases that were created
-    var canvases = document.getElementsByTagName('canvas');
+    var reg = new RegExp(/(^|\s)p5_hidden(?!\S)/g);
+    var canvases = document.getElementsByClassName('p5_hidden');
     for (var i = 0; i < canvases.length; i++) {
       var k = canvases[i];
-      if (k.dataset.hidden === 'true') {
-        k.style.visibility = '';
-        delete(k.dataset.hidden);
-      }
+      k.style.visibility = '';
+      k.className = k.className.replace(reg, '');
     }
     this._setupDone = true;
 
@@ -11943,14 +11900,11 @@ var p5 = function(sketch, node, sync) {
     // window.p5 = undefined;
   }.bind(this);
 
-  // call any registered init functions
-  this._registeredMethods.init.forEach(function (f) {
-    if (typeof(f) !== 'undefined') {
-      f.call(this);
-    }
-  }, this);
 
-  var friendlyBindGlobal = this._createFriendlyGlobalFunctionBinder();
+  // attach constants to p5 instance
+  for (var k in constants) {
+    p5.prototype[k] = constants[k];
+  }
 
   // If the user has created a global setup or draw function,
   // assume "global" mode and make everything global (i.e. on the window)
@@ -11961,16 +11915,16 @@ var p5 = function(sketch, node, sync) {
       if(typeof p5.prototype[p] === 'function') {
         var ev = p.substring(2);
         if (!this._events.hasOwnProperty(ev)) {
-          friendlyBindGlobal(p, p5.prototype[p].bind(this));
+          window[p] = p5.prototype[p].bind(this);
         }
       } else {
-        friendlyBindGlobal(p, p5.prototype[p]);
+        window[p] = p5.prototype[p];
       }
     }
     // Attach its properties to the window
     for (var p2 in this) {
       if (this.hasOwnProperty(p2)) {
-        friendlyBindGlobal(p2, this[p2]);
+        window[p2] = this[p2];
       }
     }
 
@@ -12004,6 +11958,8 @@ var p5 = function(sketch, node, sync) {
     window.removeEventListener('blur', blurHandler);
   });
 
+  // TODO: ???
+
   if (sync) {
     this._start();
   } else {
@@ -12015,10 +11971,6 @@ var p5 = function(sketch, node, sync) {
   }
 };
 
-// attach constants to p5 prototype
-for (var k in constants) {
-  p5.prototype[k] = constants[k];
-}
 
 // functions that cause preload to wait
 // more can be added by using registerPreloadMethod(func)
@@ -12032,7 +11984,7 @@ p5.prototype._preloadMethods = {
   loadFont: p5.prototype
 };
 
-p5.prototype._registeredMethods = { init: [], pre: [], post: [], remove: [] };
+p5.prototype._registeredMethods = { pre: [], post: [], remove: [] };
 
 p5.prototype._registeredPreloadMethods = {};
 
@@ -12048,77 +12000,6 @@ p5.prototype.registerMethod = function(name, m) {
     p5.prototype._registeredMethods[name] = [];
   }
   p5.prototype._registeredMethods[name].push(m);
-};
-
-p5.prototype._createFriendlyGlobalFunctionBinder = function(options) {
-  options = options || {};
-
-  var globalObject = options.globalObject || window;
-  var log = options.log || console.log.bind(console);
-  var propsToForciblyOverwrite = {
-    // p5.print actually always overwrites an existing global function,
-    // albeit one that is very unlikely to be used:
-    //
-    //   https://developer.mozilla.org/en-US/docs/Web/API/Window/print
-    'print': true
-  };
-
-  return function(prop, value) {
-    if (typeof(IS_MINIFIED) === 'undefined' &&
-        typeof(value) === 'function' &&
-        !(prop in p5.prototype._preloadMethods)) {
-      try {
-        // Because p5 has so many common function names, it's likely
-        // that users may accidentally overwrite global p5 functions with
-        // their own variables. Let's allow this but log a warning to
-        // help users who may be doing this unintentionally.
-        //
-        // For more information, see:
-        //
-        //   https://github.com/processing/p5.js/issues/1317
-
-        if (prop in globalObject && !(prop in propsToForciblyOverwrite)) {
-          throw new Error('global "' + prop + '" already exists');
-        }
-
-        // It's possible that this might throw an error because there
-        // are a lot of edge-cases in which `Object.defineProperty` might
-        // not succeed; since this functionality is only intended to
-        // help beginners anyways, we'll just catch such an exception
-        // if it occurs, and fall back to legacy behavior.
-        Object.defineProperty(globalObject, prop, {
-          configurable: true,
-          enumerable: true,
-          get: function() {
-            return value;
-          },
-          set: function(newValue) {
-            Object.defineProperty(globalObject, prop, {
-              configurable: true,
-              enumerable: true,
-              value: newValue,
-              writable: true
-            });
-            log(
-              'You just changed the value of "' + prop + '", which was ' +
-              'a p5 function. This could cause problems later if you\'re ' +
-              'not careful.'
-            );
-          }
-        });
-      } catch (e) {
-        log(
-          'p5 had problems creating the global function "' + prop + '", ' +
-          'possibly because your code is already using that name as ' +
-          'a variable. You may want to rename your variable to something ' +
-          'else.'
-        );
-        globalObject[prop] = value;
-      }
-    } else {
-      globalObject[prop] = value;
-    }
-  };
 };
 
 module.exports = p5;
@@ -12502,7 +12383,7 @@ p5.prototype.curvePoint = function(a, b, c, d, t) {
 /**
  * Evaluates the tangent to the curve at position t for points a, b, c, d.
  * The parameter t varies between 0 and 1, a and d are points on the curve,
- * and b and c are the control points.
+ * and b and c are the control points
  *
  * @method curveTangent
  * @param {Number} a coordinate of first point on the curve
@@ -12923,9 +12804,8 @@ p5.prototype.height = 0;
  * be called on user input, for example, on mouse press like the example
  * below.
  *
- * @method fullscreen
- * @param  {Boolean} [val] whether the sketch should be in fullscreen mode
- * or not
+ * @method fullScreen
+ * @param  {Boolean} [val] whether the sketch should be fullscreened or not
  * @return {Boolean} current fullscreen state
  * @example
  * <div>
@@ -12936,14 +12816,14 @@ p5.prototype.height = 0;
  * }
  * function mousePressed() {
  *   if (mouseX > 0 && mouseX < 100 && mouseY > 0 && mouseY < 100) {
- *     var fs = fullscreen();
- *     fullscreen(!fs);
+ *     var fs = fullScreen();
+ *     fullScreen(!fs);
  *   }
  * }
  * </code>
  * </div>
  */
-p5.prototype.fullscreen = function(val) {
+p5.prototype.fullScreen = function(val) {
   // no arguments, return fullscreen or not
   if (typeof val === 'undefined') {
     return document.fullscreenElement ||
@@ -13399,110 +13279,27 @@ function friendlyWelcome() {
   report(str, 'println', '#4DB200'); // auto dark green
 } */
 
-// This is a lazily-defined list of p5 symbols that may be
-// misused by beginners at top-level code, outside of setup/draw. We'd like
-// to detect these errors and help the user by suggesting they move them
+// This is a list of p5 functions/variables that are commonly misused
+// by beginners at top-level code, outside of setup/draw. We'd like to
+// detect these errors and help the user by suggesting they move them
 // into setup/draw.
 //
 // For more details, see https://github.com/processing/p5.js/issues/1121.
-var misusedAtTopLevelCode = null;
-var FAQ_URL = 'https://github.com/processing/p5.js/wiki/' +
-              'Frequently-Asked-Questions' +
-              '#why-cant-i-assign-variables-using-p5-functions-and-' +
-              'variables-before-setup';
+var misusedAtTopLevelCode = [
+  'color',
+  'random'
+];
 
-function defineMisusedAtTopLevelCode() {
-  var uniqueNamesFound = {};
-
-  var getSymbols = function(obj) {
-    return Object.getOwnPropertyNames(obj).filter(function(name) {
-      if (name[0] === '_') {
-        return false;
-      }
-      if (name in uniqueNamesFound) {
-        return false;
-      }
-
-      uniqueNamesFound[name] = true;
-
-      return true;
-    }).map(function(name) {
-      var type;
-
-      if (typeof(obj[name]) === 'function') {
-        type = 'function';
-      } else if (name === name.toUpperCase()) {
-        type = 'constant';
-      } else {
-        type = 'variable';
-      }
-
-      return {name: name, type: type};
-    });
-  };
-
-  misusedAtTopLevelCode = [].concat(
-    getSymbols(p5.prototype),
-    // At present, p5 only adds its constants to p5.prototype during
-    // construction, which may not have happened at the time a
-    // ReferenceError is thrown, so we'll manually add them to our list.
-    getSymbols(_dereq_('./constants'))
-  );
-
-  // This will ultimately ensure that we report the most specific error
-  // possible to the user, e.g. advising them about HALF_PI instead of PI
-  // when their code misuses the former.
-  misusedAtTopLevelCode.sort(function(a, b) {
-    return b.name.length - a.name.length;
-  });
-}
-
-function helpForMisusedAtTopLevelCode(e, log) {
-  if (!log) {
-    log = console.log.bind(console);
-  }
-
-  if (!misusedAtTopLevelCode) {
-    defineMisusedAtTopLevelCode();
-  }
-
-  // If we find that we're logging lots of false positives, we can
-  // uncomment the following code to avoid displaying anything if the
-  // user's code isn't likely to be using p5's global mode. (Note that
-  // setup/draw are more likely to be defined due to JS function hoisting.)
-  //
-  //if (!('setup' in window || 'draw' in window)) {
-  //  return;
-  //}
-
-  misusedAtTopLevelCode.some(function(symbol) {
-    // Note that while just checking for the occurrence of the
-    // symbol name in the error message could result in false positives,
-    // a more rigorous test is difficult because different browsers
-    // log different messages, and the format of those messages may
-    // change over time.
-    //
-    // For example, if the user uses 'PI' in their code, it may result
-    // in any one of the following messages:
-    //
-    //   * 'PI' is undefined                           (Microsoft Edge)
-    //   * ReferenceError: PI is undefined             (Firefox)
-    //   * Uncaught ReferenceError: PI is not defined  (Chrome)
-
-    if (e.message && e.message.indexOf(symbol.name) !== -1) {
-      log('%cDid you just try to use p5.js\'s ' + symbol.name +
-          (symbol.type === 'function' ? '() ' : ' ') + symbol.type +
-          '? If so, you may want to ' +
-          'move it into your sketch\'s setup() function.\n\n' +
-          'For more details, see: ' + FAQ_URL,
-          'color: #B40033' /* Dark magenta */);
-      return true;
+function helpForMisusedAtTopLevelCode(e) {
+  misusedAtTopLevelCode.forEach(function(name) {
+    if (e.message && e.message.indexOf(name) !== -1) {
+      console.log('%c Did you just try to use p5.js\'s \'' + name + '\' ' +
+                  'function or variable? If so, you may want to ' +
+                  'move it into your sketch\'s setup() function.',
+                  'color: #B40033' /* Dark magenta */);
     }
   });
 }
-
-// Exposing this primarily for unit testing.
-p5.prototype._helpForMisusedAtTopLevelCode = helpForMisusedAtTopLevelCode;
 
 if (document.readyState !== 'complete') {
   window.addEventListener('error', helpForMisusedAtTopLevelCode, false);
@@ -13518,7 +13315,7 @@ if (document.readyState !== 'complete') {
 
 module.exports = p5;
 
-},{"./constants":47,"./core":48}],52:[function(_dereq_,module,exports){
+},{"./core":48}],52:[function(_dereq_,module,exports){
 /**
  * @module DOM
  * @submodule DOM
@@ -13638,6 +13435,8 @@ p5.Element.prototype.class = function(c) {
     return this.elt.className;
   } else {
     this.elt.className = c;
+    this.width = this.elt.offsetWidth;
+    this.height = this.elt.offsetHeight;
     return this;
   }
 };
@@ -13700,41 +13499,6 @@ p5.Element.prototype.mousePressed = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse wheel is
  *                    scrolled over the element.
  * @return {p5.Element}
- * @example
- * <div class='norender'><code>
- * var cnv;
- * var d;
- * var g;
- * function setup() {
- *   cnv = createCanvas(100, 100);
- *   cnv.mouseWheel(changeSize); // attach listener for
- *                               // activity on canvas only
- *   d = 10;
- *   g = 100;
- * }
- *
- * function draw() {
- *   background(g);
- *   ellipse(width/2, height/2, d, d);
- * }
- *
- * // this function fires with mousewheel movement
- * // anywhere on screen
- * function mouseWheel() {
- *   g = g + 10;
- * }
- *
- * // this function fires with mousewheel movement
- * // over canvas only
- * function changeSize() {
- *   if (event.wheelDelta > 0) {
- *     d = d + 10;
- *   } else {
- *     d = d - 10;
- *   }
- * }
- * </code></div>
- *
  */
 p5.Element.prototype.mouseWheel = function (fxn) {
   attachListener('wheel', fxn, this);
@@ -13750,37 +13514,6 @@ p5.Element.prototype.mouseWheel = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse is
  *                    released over the element.
  * @return {p5.Element}
- * @example
- * <div class='norender'><code>
- * var cnv;
- * var d;
- * var g;
- * function setup() {
- *   cnv = createCanvas(100, 100);
- *   cnv.mouseReleased(changeGray); // attach listener for
- *                                  // activity on canvas only
- *   d = 10;
- *   g = 100;
- * }
- *
- * function draw() {
- *   background(g);
- *   ellipse(width/2, height/2, d, d);
- * }
- *
- * // this function fires after the mouse has been
- * // released
- * function mouseReleased() {
- *   d = d + 10;
- * }
- *
- * // this function fires after the mouse has been
- * // released while on canvas
- * function changeGray() {
- *   g = random(0, 255);
- * }
- * </code></div>
- *
  */
 p5.Element.prototype.mouseReleased = function (fxn) {
   attachListener('mouseup', fxn, this);
@@ -13798,36 +13531,6 @@ p5.Element.prototype.mouseReleased = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse is
  *                    clicked over the element.
  * @return {p5.Element}
- * @example
- * var cnv;
- * var d;
- * var g;
- * function setup() {
- *   cnv = createCanvas(100, 100);
- *   cnv.mouseClicked(changeGray); // attach listener for
- *                                 // activity on canvas only
- *   d = 10;
- *   g = 100;
- * }
- *
- * function draw() {
- *   background(g);
- *   ellipse(width/2, height/2, d, d);
- * }
- *
- * // this function fires after the mouse has been
- * // clicked anywhere
- * function mouseClicked() {
- *   d = d + 10;
- * }
- *
- * // this function fires after the mouse has been
- * // clicked on canvas
- * function changeGray() {
- *   g = random(0, 255);
- * }
- * </code></div>
- *
  */
 p5.Element.prototype.mouseClicked = function (fxn) {
   attachListener('click', fxn, this);
@@ -13843,43 +13546,6 @@ p5.Element.prototype.mouseClicked = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse is
  *                    moved over the element.
  * @return {p5.Element}
- * @example
- * <div class='norender'><code>
- * var cnv;
- * var d = 30;
- * var g;
- * function setup() {
- *   cnv = createCanvas(100, 100);
- *   cnv.mouseMoved(changeSize); // attach listener for
- *                               // activity on canvas only
- *   d = 10;
- *   g = 100;
- * }
- *
- * function draw() {
- *   background(g);
- *   fill(200);
- *   ellipse(width/2, height/2, d, d);
- * }
- *
- * // this function fires when mouse moves anywhere on
- * // page
- * function mouseMoved() {
- *   g = g + 5;
- *   if (g > 255) {
- *     g = 0;
- *   }
- * }
- *
- * // this function fires when mouse moves over canvas
- * function changeSize() {
- *   d = d + 2;
- *   if (d > 100) {
- *     d = 0;
- *   }
- * }
- * </code></div>
- *
  */
 p5.Element.prototype.mouseMoved = function (fxn) {
   attachListener('mousemove', fxn, this);
@@ -13896,29 +13562,6 @@ p5.Element.prototype.mouseMoved = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse is
  *                    moved over the element.
  * @return {p5.Element}
- * @example
- * <div class='norender'><code>
- * var cnv;
- * var d;
- * var g;
- * function setup() {
- *   cnv = createCanvas(100, 100);
- *   cnv.mouseOver(changeGray);
- *   d = 10;
- * }
- *
- * function draw() {
- *   ellipse(width/2, height/2, d, d);
- * }
- *
- * function changeGray() {
- *   d = d + 10;
- *   if (d > 100) {
- *     d = 0;
- *   }
- * }
- * </code></div>
- *
  */
 p5.Element.prototype.mouseOver = function (fxn) {
   attachListener('mouseover', fxn, this);
@@ -13997,19 +13640,6 @@ p5.Element.prototype.changed = function (fxn) {
  * @method input
  * @param  {Function} fxn function to be fired on user input.
  * @return {p5.Element}
- * @example
- * <div class='norender'><code>
- * // Open your console to see the output
- * function setup() {
- *   var inp = createInput('');
- *   inp.input(myInputEvent);
- * }
- *
- * function myInputEvent() {
- *   console.log('you are typing: ', this.value());
- * }
- * </code></div>
- *
  */
 p5.Element.prototype.input = function (fxn) {
   attachListener('input', fxn, this);
@@ -14025,29 +13655,6 @@ p5.Element.prototype.input = function (fxn) {
  * @param  {Function} fxn function to be fired when mouse is
  *                    moved off the element.
  * @return {p5.Element}
- * @example
- * <div class='norender'><code>
- * var cnv;
- * var d;
- * var g;
- * function setup() {
- *   cnv = createCanvas(100, 100);
- *   cnv.mouseOut(changeGray);
- *   d = 10;
- * }
- *
- * function draw() {
- *   ellipse(width/2, height/2, d, d);
- * }
- *
- * function changeGray() {
- *   d = d + 10;
- *   if (d > 100) {
- *     d = 0;
- *   }
- * }
- * </code></div>
- *
  */
 p5.Element.prototype.mouseOut = function (fxn) {
   attachListener('mouseout', fxn, this);
@@ -14221,22 +13828,6 @@ p5.Element.prototype.dragLeave = function (fxn) {
  * @param  {Function} callback triggered when files are dropped.
  * @param  {Function} callback to receive loaded file.
  * @return {p5.Element}
- * @example
- * <div><code>
- * function setup() {
- *   var c = createCanvas(100, 100);
- *   background(200);
- *   textAlign(CENTER);
- *   text('drop image', width/2, height/2);
- *   c.drop(gotFile);
- * }
- *
- * function gotFile(file) {
- *   var img = createImg(file.data).hide();
- *   // Draw the image onto the canvas
- *   image(img, 0, 0, width, height);
- * }
- * </code></div>
  */
 p5.Element.prototype.drop = function (callback, fxn) {
   // Make a file loader callback and trigger user's callback
@@ -14364,9 +13955,9 @@ p5.Graphics = function(w, h, renderer, pInst) {
   this._pixelDensity = pInst._pixelDensity;
 
   if (r === constants.WEBGL) {
-    this._renderer = new p5.Renderer3D(c, this, false);
+    this._renderer = new p5.Renderer3D(c, pInst, false);
   } else {
-    this._renderer = new p5.Renderer2D(c, this, false);
+    this._renderer = new p5.Renderer2D(c, pInst, false);
   }
 
   this._renderer.resize(w, h);
@@ -14664,7 +14255,7 @@ p5.Renderer2D.prototype.background = function() {
   } else {
     var curFill = this.drawingContext.fillStyle;
     // create background rect
-    var color = this._pInst.color.apply(this, arguments);
+    var color = this._pInst.color.apply(this._pInst, arguments);
     var newFill = color.toString();
     this.drawingContext.fillStyle = newFill;
     this.drawingContext.fillRect(0, 0, this.width, this.height);
@@ -14681,13 +14272,13 @@ p5.Renderer2D.prototype.clear = function() {
 p5.Renderer2D.prototype.fill = function() {
 
   var ctx = this.drawingContext;
-  var color = this._pInst.color.apply(this, arguments);
+  var color = this._pInst.color.apply(this._pInst, arguments);
   ctx.fillStyle = color.toString();
 };
 
 p5.Renderer2D.prototype.stroke = function() {
   var ctx = this.drawingContext;
-  var color = this._pInst.color.apply(this, arguments);
+  var color = this._pInst.color.apply(this._pInst, arguments);
   ctx.strokeStyle = color.toString();
 };
 
@@ -14763,11 +14354,7 @@ p5.Renderer2D.prototype.blend = function() {
   );
 
   this.drawingContext.globalCompositeOperation = blendMode;
-  if (this._pInst) {
-    this._pInst.copy.apply(this._pInst, copyArgs);
-  } else {
-    this.copy.apply(this, copyArgs);
-  }
+  this._pInst.copy.apply(this._pInst, copyArgs);
   this.drawingContext.globalCompositeOperation = currBlend;
 };
 
@@ -15624,8 +15211,7 @@ p5.Renderer2D.prototype.scale = function(x,y) {
 
 p5.Renderer2D.prototype.shearX = function(angle) {
   if (this._pInst._angleMode === constants.DEGREES) {
-    // undoing here, because it gets redone in tan()
-    angle = this._pInst.degrees(angle);
+    angle = this._pInst.radians(angle);
   }
   this.drawingContext.transform(1, 0, this._pInst.tan(angle), 1, 0, 0);
   return this;
@@ -15633,8 +15219,7 @@ p5.Renderer2D.prototype.shearX = function(angle) {
 
 p5.Renderer2D.prototype.shearY = function(angle) {
   if (this._pInst._angleMode === constants.DEGREES) {
-    // undoing here, because it gets redone in tan()
-    angle = this._pInst.degrees(angle);
+    angle = this._pInst.radians(angle);
   }
   this.drawingContext.transform(1, this._pInst.tan(angle), 0, 1, 0, 0);
   return this;
@@ -15745,12 +15330,9 @@ p5.Renderer2D.prototype.text = function (str, x, y, maxWidth, maxHeight) {
     }
   }
   else {
-    //offset to account for centering multiple lines of text
-    var offset = ((cars.length)*0.5-0.5)*p.textLeading();
-
     for (jj = 0; jj < cars.length; jj++) {
 
-      this._renderText(p, cars[jj], x, y-offset, finalMaxHeight);
+      this._renderText(p, cars[jj], x, y, finalMaxHeight);
       y += p.textLeading();
     }
   }
@@ -15913,7 +15495,7 @@ var defaultId = 'defaultCanvas0'; // this gets set again in createCanvas
  * @method createCanvas
  * @param  {Number} w width of the canvas
  * @param  {Number} h height of the canvas
- * @param  {String} [renderer] 'p2d' | 'webgl'
+ * @param  optional:{String} renderer 'p2d' | 'webgl'
  * @return {Object} canvas generated
  * @example
  * <div>
@@ -15963,7 +15545,7 @@ p5.prototype.createCanvas = function(w, h, renderer) {
 
   // set to invisible if still in setup (to prevent flashing with manipulate)
   if (!this._setupDone) {
-    c.dataset.hidden = true; // tag to show later
+    c.className += ' p5_hidden'; // tag to show later
     c.style.visibility='hidden';
   }
 
@@ -16236,19 +15818,16 @@ window.performance.now = (function(){
  * shim for Uint8ClampedArray.slice
  * (allows arrayCopy to work with pixels[])
  * with thanks to http://halfpapstudios.com/blog/tag/html5-canvas/
- * Enumerable set to false to protect for...in from
- * Uint8ClampedArray.prototype pollution.
  */
 (function () {
   'use strict';
-  if (typeof Uint8ClampedArray !== 'undefined' &&
-      !Uint8ClampedArray.prototype.slice) {
-    Object.defineProperty(Uint8ClampedArray.prototype, 'slice', {
-      value: Array.prototype.slice,
-      writable: true, configurable: true, enumerable: false
-    });
+
+  if (typeof Uint8ClampedArray !== 'undefined') {
+    //Firefox and Chrome
+    Uint8ClampedArray.prototype.slice = Array.prototype.slice;
   }
 }());
+
 
 },{}],58:[function(_dereq_,module,exports){
 /**
@@ -16415,9 +15994,7 @@ p5.prototype.push = function () {
   this._renderer.push();
   this._styles.push({
     _doStroke: this._renderer._doStroke,
-    _strokeSet: this._renderer._strokeSet,
     _doFill: this._renderer._doFill,
-    _fillSet: this._renderer._fillSet,
     _tint: this._renderer._tint,
     _imageMode: this._renderer._imageMode,
     _rectMode: this._renderer._rectMode,
@@ -16536,7 +16113,7 @@ p5.prototype.redraw = function () {
   var userSetup = this.setup || window.setup;
   var userDraw = this.draw || window.draw;
   if (typeof userDraw === 'function') {
-    this.resetMatrix.bind(this);
+    this.push();
     if (typeof userSetup === 'undefined') {
       this.scale(this._pixelDensity, this._pixelDensity);
     }
@@ -16548,6 +16125,7 @@ p5.prototype.redraw = function () {
     this._registeredMethods.post.forEach(function (f) {
       f.call(self);
     });
+    this.pop();
   }
 };
 
@@ -16985,7 +16563,6 @@ var isBezier = false;
 var isCurve = false;
 var isQuadratic = false;
 var isContour = false;
-var isFirstContour = true;
 
 /**
  * Use the beginContour() and endContour() functions to create negative
@@ -17358,12 +16935,7 @@ p5.prototype.endContour = function() {
   vert.moveTo = false;
   contourVertices.push(vert);
 
-  // prevent stay lines with multiple contours
-  if (isFirstContour) {
-    vertices.push(vertices[0]);
-    isFirstContour = false;
-  }
-
+  vertices.push(vertices[0]);
   for (var i = 0; i < contourVertices.length; i++) {
     vertices.push(contourVertices[i]);
   }
@@ -17421,7 +16993,6 @@ p5.prototype.endShape = function(mode) {
     isBezier = false;
     isQuadratic = false;
     isContour = false;
-    isFirstContour = true;
 
     // If the shape is closed, the first element was added as last element.
     // We must remove it again to prevent the list of vertices from growing
@@ -17664,27 +17235,6 @@ p5.prototype._updatePAccelerations = function(){
 /**
  * The system variable rotationX always contains the rotation of the
  * device along the x axis. Value is represented as 0 to +/-180 degrees.
- * <br><br>
- * Note: The order the rotations are called is important, ie. if used
- * together, it must be called in the order Z-X-Y or there might be
- * unexpected behaviour.
- *
- * @example
- * <div>
- * <code>
- * function setup(){
- *   createCanvas(100, 100, WEBGL);
- * }
- *
- * function draw(){
- *   background(200);
- *   //rotateZ(radians(rotationZ));
- *   rotateX(radians(rotationX));
- *   //rotateY(radians(rotationY));
- *   box(200, 200, 200);
- * }
- * </code>
- * </div>
  *
  * @property rotationX
  */
@@ -17692,28 +17242,7 @@ p5.prototype.rotationX = 0;
 
 /**
  * The system variable rotationY always contains the rotation of the
- * device along the y axis. Value is represented as 0 to +/-90 degrees.
- * <br><br>
- * Note: The order the rotations are called is important, ie. if used
- * together, it must be called in the order Z-X-Y or there might be
- * unexpected behaviour.
- *
- * @example
- * <div>
- * <code>
- * function setup(){
- *   createCanvas(100, 100, WEBGL);
- * }
- *
- * function draw(){
- *   background(200);
- *   //rotateZ(radians(rotationZ));
- *   //rotateX(radians(rotationX));
- *   rotateY(radians(rotationY));
- *   box(200, 200, 200);
- * }
- * </code>
- * </div>
+ * device along the y axis. Value is represented as 0 to +/-180 degrees.
  *
  * @property rotationY
  */
@@ -17725,27 +17254,6 @@ p5.prototype.rotationY = 0;
  * <br><br>
  * Unlike rotationX and rotationY, this variable is available for devices
  * with a built-in compass only.
- * <br><br>
- * Note: The order the rotations are called is important, ie. if used
- * together, it must be called in the order Z-X-Y or there might be
- * unexpected behaviour.
- *
- * @example
- * <div>
- * <code>
- * function setup(){
- *   createCanvas(100, 100, WEBGL);
- * }
- *
- * function draw(){
- *   background(200);
- *   rotateZ(radians(rotationZ));
- *   //rotateX(radians(rotationX));
- *   //rotateY(radians(rotationY));
- *   box(200, 200, 200);
- * }
- * </code>
- * </div>
  *
  * @property rotationZ
  */
@@ -17792,7 +17300,7 @@ p5.prototype.pRotationX = 0;
 /**
  * The system variable pRotationY always contains the rotation of the
  * device along the y axis in the frame previous to the current frame. Value
- * is represented as 0 to +/-90 degrees.
+ * is represented as 0 to +/-180 degrees.
  * <br><br>
  * pRotationY can also be used with rotationY to determine the rotate
  * direction of the device along the Y-axis.
@@ -18388,8 +17896,7 @@ p5.prototype._onkeyup = function (e) {
  *   } else if (key === 'b') {
  *     value = 0;
  *   }
- *   // uncomment to prevent any default behavior
- *   // return false;
+ *   return false; // prevent any default behavior
  * }
  * </code>
  * </div>
@@ -18730,24 +18237,24 @@ p5.prototype.pwinMouseY = 0;
  * @property mouseButton
  *
  * @example
-	* <div>
-	* <code>
-	* function draw() {
-	*   background(237, 34, 93);
-	*   fill(0);
-	*
-	*   if (mouseIsPressed) {
-	*     if (mouseButton == LEFT)
-	*       ellipse(50, 50, 50, 50);
-	*     if (mouseButton == RIGHT)
-	*       rect(25, 25, 50, 50);
-	*     if (mouseButton == CENTER)
-	*       triangle(23, 75, 50, 20, 78, 75);
-	*   }
-	*
-	*   print(mouseButton);
-	* }
-	* </code>
+    * <div>
+    * <code>
+    * function draw() {
+    *   background(237, 34, 93);
+    *   fill(0);
+    *
+    *   if (mouseIsPressed) {
+    *     if (mouseButton == LEFT)
+    *       ellipse(50, 50, 50, 50);
+    *     if (mouseButton == RIGHT)
+    *       rect(25, 25, 50, 50);
+    *     if (mouseButton == CENTER)
+    *       triangle(23, 75, 50, 20, 78, 75);
+    *   }
+    *
+    *   print(mouseButton);
+    * }
+    * </code>
  * </div>
  */
 p5.prototype.mouseButton = 0;
@@ -18759,21 +18266,21 @@ p5.prototype.mouseButton = 0;
  * @property mouseIsPressed
  *
  * @example
-	* <div>
-	* <code>
-	* function draw() {
-	*   background(237, 34, 93);
-	*   fill(0);
-	*
-	*   if (mouseIsPressed)
-	*     ellipse(50, 50, 50, 50);
-	*   else
-	*     rect(25, 25, 50, 50);
-	*
-	*   print(mouseIsPressed);
-	* }
-	* </code>
-	* </div>
+    * <div>
+    * <code>
+    * function draw() {
+    *   background(237, 34, 93);
+    *   fill(0);
+    *
+    *   if (mouseIsPressed)
+    *     ellipse(50, 50, 50, 50);
+    *   else
+    *     rect(25, 25, 50, 50);
+    *
+    *   print(mouseIsPressed);
+    * }
+    * </code>
+    * </div>
  */
 p5.prototype.mouseIsPressed = false;
 p5.prototype.isMousePressed = false; // both are supported
@@ -18781,7 +18288,7 @@ p5.prototype.isMousePressed = false; // both are supported
 p5.prototype._updateNextMouseCoords = function(e) {
   if(e.type === 'touchstart' ||
      e.type === 'touchmove' ||
-     e.type === 'touchend' || e.touches) {
+     e.type === 'touchend') {
     this._setProperty('_nextMouseX', this._nextTouchX);
     this._setProperty('_nextMouseY', this._nextTouchY);
   } else {
@@ -19236,7 +18743,7 @@ p5.prototype.touchIsDown = false;
 p5.prototype._updateNextTouchCoords = function(e) {
   if(e.type === 'mousedown' ||
      e.type === 'mousemove' ||
-     e.type === 'mouseup' || !e.touches) {
+     e.type === 'mouseup'){
     this._setProperty('_nextTouchX', this._nextMouseX);
     this._setProperty('_nextTouchY', this._nextMouseY);
   } else {
@@ -20274,36 +19781,16 @@ p5.prototype.saveCanvas = function() {
  *  Capture a sequence of frames that can be used to create a movie.
  *  Accepts a callback. For example, you may wish to send the frames
  *  to a server where they can be stored or converted into a movie.
- *  If no callback is provided, the browser will pop up save dialogues in an
- *  attempt to download all of the images that have just been created. With the
- *  callback provided the image data isn't saved by default but instead passed
- *  as an argument to the callback function as an array of objects, with the
- *  size of array equal to the total number of frames.
+ *  If no callback is provided, the browser will attempt to download
+ *  all of the images that have just been created.
  *
  *  @method saveFrames
- *  @param  {String}   filename
- *  @param  {String}   extension 'jpg' or 'png'
- *  @param  {Number}   duration  Duration in seconds to save the frames for.
- *  @param  {Number}   framerate  Framerate to save the frames in.
- *  @param  {Function} [callback] A callback function that will be executed
-                                  to handle the image data. This function
-                                  should accept an array as argument. The
-                                  array will contain the spcecified number of
-                                  frames of objects. Each object has three
-                                  properties: imageData - an
-                                  image/octet-stream, filename and extension.
- *  @example
- *  <div><code>
- *  function draw() {
- *    background(mouseX);
- *  }
- *
- *  function mousePressed() {
- *    saveFrames("out", "png", 1, 25, function(data){
- *      print(data);
- *    });
- *  }
- *  </code></div>
+ *  @param  {[type]}   filename  [description]
+ *  @param  {[type]}   extension [description]
+ *  @param  {[type]}   _duration [description]
+ *  @param  {[type]}   _fps      [description]
+ *  @param  {[Function]} callback  [description]
+ *  @return {[type]}             [description]
  */
 p5.prototype.saveFrames = function(fName, ext, _duration, _fps, callback) {
   var duration = _duration || 3;
@@ -20575,8 +20062,8 @@ p5.prototype.image =
     if (img.elt && img.elt.videoWidth && !img.canvas) { // video no canvas
       var actualW = img.elt.videoWidth;
       var actualH = img.elt.videoHeight;
-      dWidth = sWidth || img.elt.width;
-      dHeight = sHeight || img.elt.width*actualH/actualW;
+      dWidth = sWidth || img.width;
+      dHeight = sHeight || img.width*actualH/actualW;
       sWidth = actualW;
       sHeight = actualH;
     } else {
@@ -20980,28 +20467,6 @@ p5.Image.prototype._setProperty = function (prop, value) {
  * Loads the pixels data for this image into the [pixels] attribute.
  *
  * @method loadPixels
- * @example
- * <div><code>
- * var myImage;
- * var halfImage;
- *
- * function preload() {
- *   myImage = loadImage("assets/rockies.jpg");
- * }
- *
- * function setup() {
- *   myImage.loadPixels();
- *   halfImage = 4 * width * height/2;
- *   for(var i = 0; i < halfImage; i++){
- *     myImage.pixels[i+halfImage] = myImage.pixels[i];
- *   }
- *   myImage.updatePixels();
- * }
- *
- * function draw() {
- *   image(myImage, 0, 0);
- * }
- * </code></div>
  */
 p5.Image.prototype.loadPixels = function(){
   p5.Renderer2D.prototype.loadPixels.call(this);
@@ -21020,28 +20485,6 @@ p5.Image.prototype.loadPixels = function(){
  *                              underlying canvas
  * @param {Integer|undefined} h height of the target update area for the
  *                              underlying canvas
- * @example
- * <div><code>
- * var myImage;
- * var halfImage;
- *
- * function preload() {
- *   myImage = loadImage("assets/rockies.jpg");
- * }
- *
- * function setup() {
- *   myImage.loadPixels();
- *   halfImage = 4 * width * height/2;
- *   for(var i = 0; i < halfImage; i++){
- *     myImage.pixels[i+halfImage] = myImage.pixels[i];
- *   }
- *   myImage.updatePixels();
- * }
- *
- * function draw() {
- *   image(myImage, 0, 0);
- * }
- * </code></div>
  */
 p5.Image.prototype.updatePixels = function(x, y, w, h){
   p5.Renderer2D.prototype.updatePixels.call(this, x, y, w, h);
@@ -21064,25 +20507,6 @@ p5.Image.prototype.updatePixels = function(x, y, w, h){
  * @param  {Number}               [h] height
  * @return {Array/Color | p5.Image}     color of pixel at x,y in array format
  *                                    [R, G, B, A] or p5.Image
- * @example
- * <div><code>
- * var myImage;
- * var c;
- *
- * function preload() {
- *   myImage = loadImage("assets/rockies.jpg");
- * }
- *
- * function setup() {
- *   background(myImage);
- *   noStroke();
- *   c = myImage.get(60, 90);
- *   fill(c);
- *   rect(25, 25, 50, 50);
- * }
- *
- * //get() returns color here
- * </code></div>
  */
 p5.Image.prototype.get = function(x, y, w, h){
   return p5.Renderer2D.prototype.get.call(this, x, y, w, h);
@@ -21211,25 +20635,6 @@ p5.Image.prototype.resize = function(width, height){
  * @param  {Integer} dy Y coordinate of the destination's upper left corner
  * @param  {Integer} dw destination image width
  * @param  {Integer} dh destination image height
- * @example
- * <div><code>
- * var photo;
- * var bricks;
- * var x;
- * var y;
- *
- * function preload() {
- *   photo = loadImage("assets/rockies.jpg");
- *   bricks = loadImage("assets/bricks.jpg");
- * }
- *
- * function setup() {
- *   x = bricks.width/2;
- *   y = bricks.height/2;
- *   photo.copy(bricks, 0, 0, x, y, 0, 0, x, y);
- *   image(photo, 0, 0);
- * }
- * </code></div>
  */
 p5.Image.prototype.copy = function () {
   p5.prototype.copy.apply(this, arguments);
@@ -21301,22 +20706,6 @@ p5.Image.prototype.mask = function(p5Image) {
  *                           opaque see Filters.js for docs on each available
  *                           filter
  * @param {Number|undefined} value
- * @example
- * <div><code>
- * var photo1;
- * var photo2;
- *
- * function preload() {
- *   photo1 = loadImage("assets/rockies.jpg");
- *   photo2 = loadImage("assets/rockies.jpg");
- * }
- *
- * function setup() {
- *   photo2.filter("gray");
- *   image(photo1, 0, 0);
- *   image(photo2, width/2, 0);
- * }
- * </code></div>
  */
 p5.Image.prototype.filter = function(operation, value) {
   Filters.apply(this.canvas, Filters[operation.toLowerCase()], value);
@@ -21345,52 +20734,7 @@ p5.Image.prototype.filter = function(operation, value) {
  *
  *
  * http://blogs.adobe.com/webplatform/2013/01/28/blending-features-in-canvas/
- * @example
- * <div><code>
- * var mountains;
- * var bricks;
  *
- * function preload() {
- *   mountains = loadImage("assets/rockies.jpg");
- *   bricks = loadImage("assets/bricks_third.jpg");
- * }
- *
- * function setup() {
- *   mountains.blend(bricks, 0, 0, 33, 100, 67, 0, 33, 100, ADD);
- *   image(mountains, 0, 0);
- *   image(bricks, 0, 0);
- * }
- * </code></div>
- * <div><code>
- * var mountains;
- * var bricks;
- *
- * function preload() {
- *   mountains = loadImage("assets/rockies.jpg");
- *   bricks = loadImage("assets/bricks_third.jpg");
- * }
- *
- * function setup() {
- *   mountains.blend(bricks, 0, 0, 33, 100, 67, 0, 33, 100, DARKEST);
- *   image(mountains, 0, 0);
- *   image(bricks, 0, 0);
- * }
- * </code></div>
- * <div><code>
- * var mountains;
- * var bricks;
- *
- * function preload() {
- *   mountains = loadImage("assets/rockies.jpg");
- *   bricks = loadImage("assets/bricks_third.jpg");
- * }
- *
- * function setup() {
- *   mountains.blend(bricks, 0, 0, 33, 100, 67, 0, 33, 100, LIGHTEST);
- *   image(mountains, 0, 0);
- *   image(bricks, 0, 0);
- * }
- * </code></div>
  */
 p5.Image.prototype.blend = function() {
   p5.prototype.blend.apply(this, arguments);
@@ -21404,24 +20748,6 @@ p5.Image.prototype.blend = function() {
  * @method save
  * @param {String} filename give your file a name
  * @param  {String} extension 'png' or 'jpg'
- * @example
- * <div><code>
- * var photo;
- *
- * function preload() {
- *   photo = loadImage("assets/rockies.jpg");
- * }
- *
- * function draw() {
- *   image(photo, 0, 0);
- * }
- *
- * function keyTyped() {
- *   if (key == 's') {
- *     photo.save("photo", "png");
- *   }
- * }
- * </code></div>
  */
 p5.Image.prototype.save = function(filename, extension) {
   var mimeType;
@@ -21533,7 +20859,7 @@ _dereq_('../color/p5.Color');
  * <code>
  * var pink = color(255, 102, 204);
  * loadPixels();
- * var d = pixelDensity();
+ * var d = pixelDensity;
  * var halfImage = 4 * (width * d) * (height/2 * d);
  * for (var i = 0; i < halfImage; i+=4) {
  *   pixels[i] = red(pink);
@@ -21615,11 +20941,7 @@ p5.prototype.pixels = [];
  * </code></div>
  */
 p5.prototype.blend = function() {
-  if (this._renderer) {
-    this._renderer.blend.apply(this._renderer, arguments);
-  } else {
-    p5.Renderer2D.prototype.blend.apply(this, arguments);
-  }
+  this._renderer.blend.apply(this._renderer, arguments);
 };
 
 /**
@@ -21838,12 +21160,10 @@ p5.prototype.filter = function(operation, value) {
  * Getting the color of a single pixel with get(x, y) is easy, but not as fast
  * as grabbing the data directly from pixels[]. The equivalent statement to
  * get(x, y) using pixels[] with pixel density d is
- * <code>
- * var off = (y * width + x) * d * 4;
- * [pixels[off],
- * pixels[off+1],
- * pixels[off+2],
- * pixels[off+3]]</code>
+ * <code>[pixels[(y*width*d+x)*d],
+ * pixels[(y*width*d+x)*d+1],
+ * pixels[(y*width*d+x)*d+2],
+ * pixels[(y*width*d+x)*d+3]]</code>.
  * <br><br>
  * See the reference for pixels[] for more information.
  *
@@ -21904,7 +21224,7 @@ p5.prototype.get = function(x, y, w, h){
  *
  * function setup() {
  *   image(img, 0, 0);
- *   var d = pixelDensity();
+ *   var d = pixelDensity;
  *   var halfImage = 4 * (img.width * d) *
        (img.height/2 * d);
  *   loadPixels();
@@ -22012,8 +21332,8 @@ p5.prototype.set = function (x, y, imgOrCol) {
  *
  * function setup() {
  *   image(img, 0, 0);
- *   var halfImage = 4 * (img.width * pixelDensity()) *
- *     (img.height * pixelDensity()/2);
+ *   var halfImage = 4 * (img.width * pixelDensity) *
+ *     (img.height * pixelDensity/2);
  *   loadPixels();
  *   for (var i = 0; i < halfImage; i++) {
  *     pixels[i+halfImage] = pixels[i];
@@ -22105,8 +21425,8 @@ p5._getDecrementPreload = function () {
  * }
  * </code></div>
  *
- * Outside of preload(), you may supply a callback function to handle the
- * object:
+ * <p>Outside of preload(), you may supply a callback function to handle the
+ * object:</p>
  *
  * <div><code>
  * function setup() {
@@ -22638,8 +21958,8 @@ p5.prototype.loadTable = function (path) {
       if (header) {
         t.columns = records.shift();
       } else {
-        for (i = 0; i < records[0].length; i++) {
-          t.columns[i] = 'null';
+        for (i = 0; i < records.length; i++) {
+          t.columns[i] = i.toString();
         }
       }
       var row;
@@ -22691,47 +22011,22 @@ function makeObject(row, headers) {
   return ret;
 }
 
-/*global parseXML */
-p5.prototype.parseXML = function (two) {
-  var one = new p5.XML();
-  var i;
-  if (two.children.length) {
-    for ( i = 0; i < two.children.length; i++ ) {
-      var node = parseXML(two.children[i]);
-      one.addChild(node);
-    }
-    one.setName(two.nodeName);
-    one._setCont(two.textContent);
-    one._setAttributes(two);
-    for (var j = 0; j < one.children.length; j++) {
-      one.children[j].parent = one;
-    }
-    return one;
-  }
-  else {
-    one.setName(two.nodeName);
-    one._setCont(two.textContent);
-    one._setAttributes(two);
-    return one;
-  }
-};
-
 /**
  * Reads the contents of a file and creates an XML object with its values.
  * If the name of the file is used as the parameter, as in the above example,
  * the file must be located in the sketch directory/folder.
- *
+ * <br><br>
  * Alternatively, the file maybe be loaded from anywhere on the local
  * computer using an absolute path (something that starts with / on Unix and
  * Linux, or a drive letter on Windows), or the filename parameter can be a
  * URL for a file found on a network.
- *
+ * <br><br>
  * This method is asynchronous, meaning it may not finish before the next
  * line in your sketch is executed. Calling loadXML() inside preload()
  * guarantees to complete the operation before setup() and draw() are called.
- *
- * <p>Outside of preload(), you may supply a callback function to handle the
- * object:</p>
+ * <br><br>
+ * Outside of preload(), you may supply a callback function to handle the
+ * object:
  *
  * @method loadXML
  * @param  {String}   filename   name of the file or URL to load
@@ -22744,8 +22039,9 @@ p5.prototype.parseXML = function (two) {
  * @return {Object}              XML object containing data
  */
 p5.prototype.loadXML = function (path, callback, errorCallback) {
-  var ret = {};
+  var ret = document.implementation.createDocument(null, null);
   var decrementPreload = p5._getDecrementPreload.apply(this, arguments);
+
   reqwest({
       url: path,
       type: 'xml',
@@ -22761,10 +22057,8 @@ p5.prototype.loadXML = function (path, callback, errorCallback) {
       }
     })
     .then(function (resp) {
-      var xml = parseXML(resp.documentElement);
-      for(var key in xml) {
-        ret[key] = xml[key];
-      }
+      var x = resp.documentElement;
+      ret.appendChild(x);
       if (typeof callback !== 'undefined') {
         callback(ret);
       }
@@ -22780,6 +22074,12 @@ p5.prototype.loadXML = function (path, callback, errorCallback) {
 //   // TODO
 
 // };
+
+p5.prototype.parseXML = function () {
+  // TODO
+  throw 'not yet implemented';
+
+};
 
 p5.prototype.selectFolder = function () {
   // TODO
@@ -23269,7 +22569,7 @@ function escapeHelper(content) {
  *  @method saveTable
  *  @param  {p5.Table} Table  the Table object to save to a file
  *  @param  {String} filename the filename to which the Table should be saved
- *  @param  {String} [options]  can be one of "tsv", "csv", or "html"
+ *  @param  {[String]} options  can be one of "tsv", "csv", or "html"
  *  @example
  *  <div><code>
  *  var table;
@@ -23563,38 +22863,38 @@ p5.Table = function (rows) {
  *  @param   {p5.TableRow} [row] row to be added to the table
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   //add a row
-	*   var newRow = table.addRow();
-	*   newRow.setString("id", table.getRowCount() - 1);
-	*   newRow.setString("species", "Canis Lupus");
-	*   newRow.setString("name", "Wolf");
-	*
-	*   //print the results
-	*   for (var r = 0; r < table.getRowCount(); r++)
-	*     for (var c = 0; c < table.getColumnCount(); c++)
-	*       print(table.getString(r, c));
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   //add a row
+    *   var newRow = table.addRow();
+    *   newRow.setString("id", table.getRowCount() - 1);
+    *   newRow.setString("species", "Canis Lupus");
+    *   newRow.setString("name", "Wolf");
+    *
+    *   //print the results
+    *   for (var r = 0; r < table.getRowCount(); r++)
+    *     for (var c = 0; c < table.getColumnCount(); c++)
+    *       print(table.getString(r, c));
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.addRow = function(row) {
   // make sure it is a valid TableRow
@@ -23616,35 +22916,35 @@ p5.Table.prototype.addRow = function(row) {
  * @param   {Number} id ID number of the row to remove
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   //remove the first row
-	*   var r = table.removeRow(0);
-	*
-	*   //print the results
-	*   for (var r = 0; r < table.getRowCount(); r++)
-	*     for (var c = 0; c < table.getColumnCount(); c++)
-	*       print(table.getString(r, c));
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   //remove the first row
+    *   var r = table.removeRow(0);
+    *
+    *   //print the results
+    *   for (var r = 0; r < table.getRowCount(); r++)
+    *     for (var c = 0; c < table.getColumnCount(); c++)
+    *       print(table.getString(r, c));
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.removeRow = function(id) {
   this.rows[id].table = null; // remove reference to table
@@ -23663,33 +22963,33 @@ p5.Table.prototype.removeRow = function(id) {
  * @return {TableRow} p5.TableRow object
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   var row = table.getRow(1);
-	*   //print it column by column
-	*   //note: a row is an object, not an array
-	*   for (var c = 0; c < table.getColumnCount(); c++)
-	*     print(row.getString(c));
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   var row = table.getRow(1);
+    *   //print it column by column
+    *   //note: a row is an object, not an array
+    *   for (var c = 0; c < table.getColumnCount(); c++)
+    *     print(row.getString(c));
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.getRow = function(r) {
   return this.rows[r];
@@ -23702,38 +23002,38 @@ p5.Table.prototype.getRow = function(r) {
  *  @return {Array}   Array of p5.TableRows
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   var rows = table.getRows();
-	*
-	*   //warning: rows is an array of objects
-	*   for (var r = 0; r < rows.length; r++)
-	*     rows[r].set("name", "Unicorn");
-	*
-	*   //print the results
-	*   for (var r = 0; r < table.getRowCount(); r++)
-	*     for (var c = 0; c < table.getColumnCount(); c++)
-	*       print(table.getString(r, c));
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   var rows = table.getRows();
+    *
+    *   //warning: rows is an array of objects
+    *   for (var r = 0; r < rows.length; r++)
+    *     rows[r].set("name", "Unicorn");
+    *
+    *   //print the results
+    *   for (var r = 0; r < table.getRowCount(); r++)
+    *     for (var c = 0; c < table.getColumnCount(); c++)
+    *       print(table.getString(r, c));
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.getRows = function() {
   return this.rows;
@@ -23753,32 +23053,32 @@ p5.Table.prototype.getRows = function() {
  *  @return {TableRow}
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   //find the animal named zebra
-	*   var row = table.findRow("Zebra", "name");
-	*   //find the corresponding species
-	*   print(row.getString("species"));
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   //find the animal named zebra
+    *   var row = table.findRow("Zebra", "name");
+    *   //find the corresponding species
+    *   print(row.getString("species"));
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.findRow = function(value, column) {
   // try the Object
@@ -23815,37 +23115,37 @@ p5.Table.prototype.findRow = function(value, column) {
  *  @return {Array}        An Array of TableRow objects
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   //add another goat
-	*   var newRow = table.addRow();
-	*   newRow.setString("id", table.getRowCount() - 1);
-	*   newRow.setString("species", "Scape Goat");
-	*   newRow.setString("name", "Goat");
-	*
-	*   //find the rows containing animals named Goat
-	*   var rows = table.findRows("Goat", "name");
-	*   print(rows.length + " Goats found");
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   //add another goat
+    *   var newRow = table.addRow();
+    *   newRow.setString("id", table.getRowCount() - 1);
+    *   newRow.setString("species", "Scape Goat");
+    *   newRow.setString("name", "Goat");
+    *
+    *   //find the rows containing animals named Goat
+    *   var rows = table.findRows("Goat", "name");
+    *   print(rows.length + " Goats found");
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.findRows = function(value, column) {
   var ret = [];
@@ -23942,31 +23242,31 @@ p5.Table.prototype.matchRows = function(regexp, column) {
  *  @return {Array}       Array of column values
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   //getColumn returns an array that can be printed directly
-	*   print(table.getColumn("species"));
-	*   //outputs ["Capra hircus", "Panthera pardus", "Equus zebra"]
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   //getColumn returns an array that can be printed directly
+    *   print(table.getColumn("species"));
+    *   //outputs ["Capra hircus", "Panthera pardus", "Equus zebra"]
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.getColumn = function(value) {
   var ret = [];
@@ -23989,31 +23289,31 @@ p5.Table.prototype.getColumn = function(value) {
  *  @method  clearRows
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   table.clearRows();
-	*   print(table.getRowCount() + " total rows in table");
-	*   print(table.getColumnCount() + " total columns in table");
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   table.clearRows();
+    *   print(table.getRowCount() + " total rows in table");
+    *   print(table.getColumnCount() + " total columns in table");
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.clearRows = function() {
   delete this.rows;
@@ -24030,37 +23330,37 @@ p5.Table.prototype.clearRows = function() {
  *  @param {String} [title] title of the given column
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   table.addColumn("carnivore");
-	*   table.set(0, "carnivore", "no");
-	*   table.set(1, "carnivore", "yes");
-	*   table.set(2, "carnivore", "no");
-	*
-	*   //print the results
-	*   for (var r = 0; r < table.getRowCount(); r++)
-	*     for (var c = 0; c < table.getColumnCount(); c++)
-	*       print(table.getString(r, c));
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   table.addColumn("carnivore");
+    *   table.set(0, "carnivore", "no");
+    *   table.set(1, "carnivore", "yes");
+    *   table.set(2, "carnivore", "no");
+    *
+    *   //print the results
+    *   for (var r = 0; r < table.getRowCount(); r++)
+    *     for (var c = 0; c < table.getColumnCount(); c++)
+    *       print(table.getString(r, c));
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.addColumn = function(title) {
   var t = title || null;
@@ -24191,30 +23491,30 @@ p5.Table.prototype.trim = function(column) {
  *  @param  {String|Number} column columnName (string) or ID (number)
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   table.removeColumn("id");
-	*   print(table.getColumnCount());
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   table.removeColumn("id");
+    *   print(table.getColumnCount());
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.removeColumn = function(c) {
   var cString;
@@ -24256,35 +23556,35 @@ p5.Table.prototype.removeColumn = function(c) {
  * @param {String|Number} value  value to assign
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   table.set(0, "species", "Canis Lupus");
-	*   table.set(0, "name", "Wolf");
-	*
-	*   //print the results
-	*   for (var r = 0; r < table.getRowCount(); r++)
-	*     for (var c = 0; c < table.getColumnCount(); c++)
-	*       print(table.getString(r, c));
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   table.set(0, "species", "Canis Lupus");
+    *   table.set(0, "name", "Wolf");
+    *
+    *   //print the results
+    *   for (var r = 0; r < table.getRowCount(); r++)
+    *     for (var c = 0; c < table.getColumnCount(); c++)
+    *       print(table.getString(r, c));
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.set = function(row, column, value) {
   this.rows[row].set(column, value);
@@ -24302,32 +23602,32 @@ p5.Table.prototype.set = function(row, column, value) {
  * @param {Number} value  value to assign
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   table.setNum(1, "id", 1);
-	*
-	*   print(table.getColumn(0));
-	*   //["0", 1, "2"]
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   table.setNum(1, "id", 1);
+    *
+    *   print(table.getColumn(0));
+    *   //["0", 1, "2"]
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.setNum = function(row, column, value){
   this.rows[row].setNum(column, value);
@@ -24361,32 +23661,32 @@ p5.Table.prototype.setString = function(row, column, value){
  * @return {String|Number}
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   print(table.get(0, 1));
-	*   //Capra hircus
-	*   print(table.get(0, "species"));
-	*   //Capra hircus
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   print(table.get(0, 1));
+    *   //Capra hircus
+    *   print(table.get(0, "species"));
+    *   //Capra hircus
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.get = function(row, column) {
   return this.rows[row].get(column);
@@ -24404,30 +23704,30 @@ p5.Table.prototype.get = function(row, column) {
  * @return {Number}
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   print(table.getNum(1, 0) + 100);
-	*   //id 1 + 100 = 101
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   print(table.getNum(1, 0) + 100);
+    *   //id 1 + 100 = 101
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.getNum = function(row, column) {
   return this.rows[row].getNum(column);
@@ -24445,33 +23745,33 @@ p5.Table.prototype.getNum = function(row, column) {
  * @return {String}
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   var tableArray = table.getArray();
-	*
-	*   //output each row as array
-	*   for (var i = 0; i < tableArray.length; i++)
-	*     print(tableArray[i]);
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   var tableArray = table.getArray();
+    *
+    *   //output each row as array
+    *   for (var i = 0; i < tableArray.length; i++)
+    *     print(tableArray[i]);
+    * }
+    * </code>
+    * </div>
  */
 p5.Table.prototype.getString = function(row, column) {
   return this.rows[row].getString(column);
@@ -24488,32 +23788,32 @@ p5.Table.prototype.getString = function(row, column) {
  * @return {Object}
  *
  * @example
-	* <div class="norender">
-	* <code>
-	* // Given the CSV file "mammals.csv"
-	* // in the project's "assets" folder:
-	* //
-	* // id,species,name
-	* // 0,Capra hircus,Goat
-	* // 1,Panthera pardus,Leopard
-	* // 2,Equus zebra,Zebra
-	*
-	* var table;
-	*
-	* function preload() {
-	*   //my table is comma separated value "csv"
-	*   //and has a header specifying the columns labels
-	*   table = loadTable("assets/mammals.csv", "csv", "header");
-	* }
-	*
-	* function setup() {
-	*   var tableObject = table.getObject();
-	*
-	*   print(tableObject);
-	*   //outputs an object
-	* }
-	* </code>
-	* </div>
+    * <div class="norender">
+    * <code>
+    * // Given the CSV file "mammals.csv"
+    * // in the project's "assets" folder:
+    * //
+    * // id,species,name
+    * // 0,Capra hircus,Goat
+    * // 1,Panthera pardus,Leopard
+    * // 2,Equus zebra,Zebra
+    *
+    * var table;
+    *
+    * function preload() {
+    *   //my table is comma separated value "csv"
+    *   //and has a header specifying the columns labels
+    *   table = loadTable("assets/mammals.csv", "csv", "header");
+    * }
+    *
+    * function setup() {
+    *   var tableObject = table.getObject();
+    *
+    *   print(tableObject);
+    *   //outputs an object
+    * }
+    * </code>
+    * </div>
 
  */
 p5.Table.prototype.getObject = function (headerColumn) {
@@ -24725,760 +24025,6 @@ p5.TableRow.prototype.getString = function(column) {
 module.exports = p5.TableRow;
 
 },{"../core/core":48}],73:[function(_dereq_,module,exports){
-/**
- * @module IO
- * @submodule XML
- * @requires core
- */
-
-'use strict';
-
-var p5 = _dereq_('../core/core');
-
-
-p5.XML = function () {
-  this.name = null; //done
-  this.attributes = {}; //done
-  this.children = [];
-  this.parent = null;
-  this.content = null; //done
-};
-
-
-/**
- * Gets a copy of the element's parent. Returns the parent as another
- * p5.XML object.
- *
- * @method getParent
- * @return {Object}   element parent
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var children = xml.getChildren("animal");
- *   var parent = children[1].getParent();
- *   print(parent.getName());
- * }
- *
- * // Sketch prints:
- * // mammals
- * </code></div>
- */
-p5.XML.prototype.getParent = function() {
-  return this.parent;
-};
-
-/**
- *  Gets the element's full name, which is returned as a String.
- *
- * @method getName
- * @return {String} the name of the node
- * @example&lt;animal
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   println(xml.getName());
- * }
- *
- * // Sketch prints:
- * // mammals
- * </code></div>
- */
-p5.XML.prototype.getName = function() {
-  return this.name;
-};
-
-/**
- * Sets the element's name, which is specified as a String.
- *
- * @method setName
- * @param {String} the new name of the node
- * @example&lt;animal
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   print(xml.getName());
- *   xml.setName("fish");
- *   print(xml.getName());
- * }
- *
- * // Sketch prints:
- * // mammals
- * // fish
- * </code></div>
- */
-p5.XML.prototype.setName = function(name) {
-  this.name = name;
-};
-
-/**
- * Checks whether or not the element has any children, and returns the result
- * as a boolean.
- *
- * @method hasChildren
- * @return {boolean}
- * @example&lt;animal
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   print(xml.hasChildren());
- * }
- *
- * // Sketch prints:
- * // true
- * </code></div>
- */
-p5.XML.prototype.hasChildren = function() {
-  return this.children.length > 0;
-};
-
-/**
- * Get the names of all of the element's children, and returns the names as an
- * array of Strings. This is the same as looping through and calling getName()
- * on each child element individually.
- *
- * @method listChildren
- * @return {Array} names of the children of the element
- * @example&lt;animal
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   print(xml.listChildren());
- * }
- *
- * // Sketch prints:
- * // ["animal", "animal", "animal"]
- * </code></div>
- */
-p5.XML.prototype.listChildren = function() {
-  return this.children.map(function(c) { return c.name; });
-};
-
-/**
- * Returns all of the element's children as an array of p5.XML objects. When
- * the name parameter is specified, then it will return all children that match
- * that name.
- *
- * @method getChildren
- * @param {String} [name] element name
- * @return {Array} children of the element
- * @example&lt;animal
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var animals = xml.getChildren("animal");
- *
- *   for (var i = 0; i < animals.length; i++) {
- *     print(animals[i].getContent());
- *   }
- * }
- *
- * // Sketch prints:
- * // "Goat"
- * // "Leopard"
- * // "Zebra"
- * </code></div>
- */
-p5.XML.prototype.getChildren = function(param) {
-  if (param) {
-    return this.children.filter(function(c) { return c.name === param; });
-  }
-  else {
-    return this.children;
-  }
-};
-
-/**
- * Returns the first of the element's children that matches the name parameter
- * or the child of the given index.It returns undefined if no matching
- * child is found.
- *
- * @method getChild
- * @param {String|Number} name element name or index
- * @return {p5.XML}
- * @example&lt;animal
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.getContent());
- * }
- *
- * // Sketch prints:
- * // "Goat"
- * </code></div>
- * <div class='norender'><code>
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var secondChild = xml.getChild(1);
- *   print(secondChild.getContent());
- * }
- *
- * // Sketch prints:
- * // "Leopard"
- * </code></div>
- */
-p5.XML.prototype.getChild = function(param) {
-  if(typeof param === 'string') {
-    return this.children.find(function(c) {
-      return c.name === param;
-    });
-  }
-  else {
-    return this.children[param];
-  }
-};
-
-/**
- * Appends a new child to the element. The child can be specified with
- * either a String, which will be used as the new tag's name, or as a
- * reference to an existing p5.XML object.
- * A reference to the newly created child is returned as an p5.XML object.
- *
- * @method addChild
- * @param {Object} a p5.XML Object which will be the child to be added
- */
-p5.XML.prototype.addChild = function(node) {
-  if (node instanceof p5.XML) {
-    this.children.push(node);
-  } else {
-    // PEND
-  }
-};
-
-/**
- * Removes the element specified by name or index.
- *
- * @method removeChild
- * @param {String|Number} name element name or index
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   xml.removeChild("animal");
- *   var children = xml.getChildren();
- *   for (var i=0; i<children.length; i++) {
- *     print(children[i].getContent());
- *   }
- * }
- *
- * // Sketch prints:
- * // "Leopard"
- * // "Zebra"
- * </code></div>
- * <div class='norender'><code>
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   xml.removeChild(1);
- *   var children = xml.getChildren();
- *   for (var i=0; i<children.length; i++) {
- *     print(children[i].getContent());
- *   }
- * }
- *
- * // Sketch prints:
- * // "Goat"
- * // "Zebra"
- * </code></div>
- */
-p5.XML.prototype.removeChild = function(param) {
-  var ind = -1;
-  if(typeof param === 'string') {
-    for (var i=0; i<this.children.length; i++) {
-      if (this.children[i].name === param) {
-        ind = i;
-        break;
-      }
-    }
-  } else {
-    ind = param;
-  }
-  if (ind !== -1) {
-    this.children.splice(ind, 1);
-  }
-};
-
-
-/**
- * Counts the specified element's number of attributes, returned as an Number.
- *
- * @method getAttributeCount
- * @return {Number}
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.getAttributeCount());
- * }
- *
- * // Sketch prints:
- * // 2
- * </code></div>
- */
-p5.XML.prototype.getAttributeCount = function() {
-  return Object.keys(this.attributes).length;
-};
-
-/**
- * Gets all of the specified element's attributes, and returns them as an
- * array of Strings.
- *
- * @method listAttributes
- * @return {Array} an array of strings containing the names of attributes
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.listAttributes());
- * }
- *
- * // Sketch prints:
- * // ["id", "species"]
- * </code></div>
- */
-p5.XML.prototype.listAttributes = function() {
-  return Object.keys(this.attributes);
-};
-
-/**
- *  Checks whether or not an element has the specified attribute.
- *
- * @method hasAttribute
- * @param {String} the attribute to be checked
- * @return {boolean} true if attribute found else false
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.hasAttribute("species"));
- *   print(firstChild.hasAttribute("color"));
- * }
- *
- * // Sketch prints:
- * // true
- * // false
- * </code></div>
- */
-p5.XML.prototype.hasAttribute = function(name) {
-  return this.attributes[name] ? true : false;
-};
-
-/**
- * Returns an attribute value of the element as an Number. If the defaultValue
- * parameter is specified and the attribute doesn't exist, then defaultValue
- * is returned. If no defaultValue is specified and the attribute doesn't
- * exist, the value 0 is returned.
- *
- * @method getNumber
- * @param {String} name            the non-null full name of the attribute
- * @param {Number} [defaultValue]  the default value of the attribute
- * @return {Number}
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.getNumber("id"));
- * }
- *
- * // Sketch prints:
- * // 0
- * </code></div>
- */
-p5.XML.prototype.getNumber = function(name, defaultValue) {
-  return Number(this.attributes[name]) || defaultValue || 0;
-};
-
-/**
- * Returns an attribute value of the element as an String. If the defaultValue
- * parameter is specified and the attribute doesn't exist, then defaultValue
- * is returned. If no defaultValue is specified and the attribute doesn't
- * exist, null is returned.
- *
- * @method getString
- * @param {String} name            the non-null full name of the attribute
- * @param {Number} [defaultValue]  the default value of the attribute
- * @return {Number}
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.getString("species"));
- * }
- *
- * // Sketch prints:
- * // "Capra hircus"
- * </code></div>
- */
-p5.XML.prototype.getString = function(name, defaultValue) {
-  return String(this.attributes[name]) || defaultValue || null;
-};
-
-/**
- * Sets the content of an element's attribute. The first parameter specifies
- * the attribute name, while the second specifies the new content.
- *
- * @method setAttribute
- * @param {String} name            the full name of the attribute
- * @param {Number} value           the value of the attribute
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.getString("species"));
- *   firstChild.setAttribute("species", "Jamides zebra");
- *   print(firstChild.getString("species"));
- * }
- *
- * // Sketch prints:
- * // "Capra hircus"
- * // "Jamides zebra"
- * </code></div>
- */
-p5.XML.prototype.setAttribute = function(name, value) {
-  if (this.attributes[name]) {
-    this.attributes[name] = value;
-  }
-};
-
-/**
- * Returns the content of an element. If there is no such content,
- * defaultValue is returned if specified, otherwise null is returned.
- *
- * @method getContent
- * @param {String} [defaultValue] value returned if no content is found
- * @return {String}
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.getContent());
- * }
- *
- * // Sketch prints:
- * // "Goat"
- * </code></div>
- */
-p5.XML.prototype.getContent = function(defaultValue) {
-  return this.content || defaultValue || null;
-};
-
-/**
- * Sets the element's content.
- *
- * @method setContent
- * @param {String} text the new content
- * @example
- * <div class='norender'><code>
- * // The following short XML file called "mammals.xml" is parsed
- * // in the code below.
- * //
- * // <?xml version="1.0"?>
- * // &lt;mammals&gt;
- * //   &lt;animal id="0" species="Capra hircus">Goat&lt;/animal&gt;
- * //   &lt;animal id="1" species="Panthera pardus">Leopard&lt;/animal&gt;
- * //   &lt;animal id="2" species="Equus zebra">Zebra&lt;/animal&gt;
- * // &lt;/mammals&gt;
- *
- * var xml;
- *
- * function preload() {
- *   xml = loadXML("assets/mammals.xml");
- * }
- *
- * function setup() {
- *   var firstChild = xml.getChild("animal");
- *   print(firstChild.getContent());
- *   firstChild.setContent("Mountain Goat");
- *   print(firstChild.getContent());
- * }
- *
- * // Sketch prints:
- * // "Goat"
- * // "Mountain Goat"
- * </code></div>
- */
-p5.XML.prototype.setContent = function( content ) {
-  if(!this.children.length) {
-    this.content = content;
-  }
-};
-
-/* HELPERS */
-/**
- * This method is called while the parsing of XML (when loadXML() is
- * called). The difference between this method and the setContent()
- * method defined later is that this one is used to set the content
- * when the node in question has more nodes under it and so on and
- * not directly text content. While in the other one is used when
- * the node in question directly has text inside it.
- *
- */
-p5.XML.prototype._setCont = function(content) {
-  var str;
-  str = content;
-  str = str.replace(/\s\s+/g, ',');
-  //str = str.split(',');
-  this.content = str;
-};
-
-/**
- * This method is called while the parsing of XML (when loadXML() is
- * called). The XML node is passed and its attributes are stored in the
- * p5.XML's attribute Object.
- *
- */
-p5.XML.prototype._setAttributes = function(node) {
-  var  i, att = {};
-  for( i = 0; i < node.attributes.length; i++) {
-    att[node.attributes[i].nodeName] = node.attributes[i].nodeValue;
-  }
-  this.attributes = att;
-};
-
-
-},{"../core/core":48}],74:[function(_dereq_,module,exports){
 /**
  * @module Math
  * @submodule Calculation
@@ -25854,7 +24400,7 @@ p5.prototype.mag = function(x, y) {
  * @param  {Number} start1 lower bound of the value's current range
  * @param  {Number} stop1  upper bound of the value's current range
  * @param  {Number} start2 lower bound of the value's target range
- * @param  {Number} stop2  upper bound of the value's target range
+ * @param  {Number} stop   upper bound of the value's target range
  * @return {Number}        remapped number
  * @example
  *   <div><code>
@@ -26157,7 +24703,7 @@ p5.prototype.sqrt = Math.sqrt;
 
 module.exports = p5;
 
-},{"../core/core":48}],75:[function(_dereq_,module,exports){
+},{"../core/core":48}],74:[function(_dereq_,module,exports){
 /**
  * @module Math
  * @submodule Math
@@ -26191,7 +24737,7 @@ p5.prototype.createVector = function (x, y, z) {
 
 module.exports = p5;
 
-},{"../core/core":48}],76:[function(_dereq_,module,exports){
+},{"../core/core":48}],75:[function(_dereq_,module,exports){
 //////////////////////////////////////////////////////////////
 
 // http://mrl.nyu.edu/~perlin/noise/
@@ -26480,7 +25026,7 @@ p5.prototype.noiseSeed = function(seed) {
 
 module.exports = p5;
 
-},{"../core/core":48}],77:[function(_dereq_,module,exports){
+},{"../core/core":48}],76:[function(_dereq_,module,exports){
 /**
  * @module Math
  * @submodule Math
@@ -26634,7 +25180,7 @@ p5.Vector.prototype.set = function (x, y, z) {
  * <div class="norender">
  * <code>
  * var v1 = createVector(1, 2, 3);
- * var v2 = v1.copy();
+ * var v2 = v.copy();
  * print(v1.x == v2.x && v1.y == v2.y && v1.z == v2.z);
  * // Prints "true"
  * </code>
@@ -27520,7 +26066,7 @@ p5.Vector.angleBetween = function (v1, v2) {
 
 module.exports = p5.Vector;
 
-},{"../core/constants":47,"../core/core":48,"./polargeometry":78}],78:[function(_dereq_,module,exports){
+},{"../core/constants":47,"../core/core":48,"./polargeometry":77}],77:[function(_dereq_,module,exports){
 
 module.exports = {
 
@@ -27534,7 +26080,7 @@ module.exports = {
 
 };
 
-},{}],79:[function(_dereq_,module,exports){
+},{}],78:[function(_dereq_,module,exports){
 /**
  * @module Math
  * @submodule Random
@@ -27606,22 +26152,17 @@ p5.prototype.randomSeed = function(seed) {
 };
 
 /**
- * Return a random floating-point number.
+ * Return a random number.
  *
  * Takes either 0, 1 or 2 arguments.
- *
- * If no argument is given, returns a random number from 0
- * up to (but not including) 1.
- *
- * If one argument is given, returns a random number from 0 up to
- * (but not including) the number.
- *
- * If two arguments are given, returns a random number from the
- * first argument up to (but not including) the second argument.
+ * If no argument is given, returns a random number between 0 and 1.
+ * If one argument is given, returns a random number between 0 and the number.
+ * If two arguments are given, returns a random number between them,
+ * inclusive.
  *
  * @method random
- * @param  {Number} [min]   the lower bound (inclusive)
- * @param  {Number} [max]   the upper bound (exclusive)
+ * @param  {Number} min   the lower bound
+ * @param  {Number} max   the upper bound
  * @return {Number} the random number
  * @example
  * <div>
@@ -27755,7 +26296,7 @@ p5.prototype.randomGaussian = function(mean, sd)  {
 
 module.exports = p5;
 
-},{"../core/core":48}],80:[function(_dereq_,module,exports){
+},{"../core/core":48}],79:[function(_dereq_,module,exports){
 /**
  * @module Math
  * @submodule Trigonometry
@@ -28095,7 +26636,7 @@ p5.prototype.angleMode = function(mode) {
 
 module.exports = p5;
 
-},{"../core/constants":47,"../core/core":48,"./polargeometry":78}],81:[function(_dereq_,module,exports){
+},{"../core/constants":47,"../core/core":48,"./polargeometry":77}],80:[function(_dereq_,module,exports){
 /**
  * @module Typography
  * @submodule Attributes
@@ -28109,19 +26650,9 @@ module.exports = p5;
 var p5 = _dereq_('../core/core');
 
 /**
- * Sets the current alignment for drawing text. Accepts two
- * arguments: horizAlign (LEFT, CENTER, or RIGHT) and
- * vertAlign (TOP, BOTTOM, CENTER, or BASELINE).
- *
- * The horizAlign parameter is in reference to the x value
- * of the text() function, while the vertAlign parameter is
- * in reference to the y value.
- *
- * So if you write textAlign(LEFT), you are aligning the left
- * edge of your text to the x value you give in text(). If you
- * write textAlign(RIGHT, TOP), you are aligning the right edge
- * of your text to the x value and the top of edge of the text
- * to the y value.
+ * Sets the current alignment for drawing text. The parameters LEFT, CENTER,
+ * and RIGHT set the alignment of text in relation to the values for
+ * the x and y parameters of the text() function.
  *
  * @method textAlign
  * @param {Number/Constant} horizAlign horizontal alignment, either LEFT,
@@ -28317,7 +26848,7 @@ p5.prototype._updateTextMetrics = function() {
 
 module.exports = p5;
 
-},{"../core/core":48}],82:[function(_dereq_,module,exports){
+},{"../core/core":48}],81:[function(_dereq_,module,exports){
 /**
  * @module Typography
  * @submodule Loading & Displaying
@@ -28402,7 +26933,7 @@ p5.prototype.text = function(str, x, y, maxWidth, maxHeight) {
  *
  * @method textFont
  * @param {Object|String} f a font loaded via loadFont(), or a String
- *  representing a browser-based default font.
+ *  representing a browser-based dfault font.
  * @return {Object} this
  * @example
  * <div>
@@ -28462,7 +26993,7 @@ p5.prototype.textFont = function(theFont, theSize) {
 
 module.exports = p5;
 
-},{"../core/constants":47,"../core/core":48,"../core/error_helpers":51}],83:[function(_dereq_,module,exports){
+},{"../core/constants":47,"../core/core":48,"../core/error_helpers":51}],82:[function(_dereq_,module,exports){
 /**
  * This module defines the p5.Font class and functions for
  * drawing text to the display canvas.
@@ -29505,7 +28036,7 @@ function cacheKey() {
 
 module.exports = p5.Font;
 
-},{"../core/constants":47,"../core/core":48}],84:[function(_dereq_,module,exports){
+},{"../core/constants":47,"../core/core":48}],83:[function(_dereq_,module,exports){
 /**
  * @module Data
  * @submodule Array Functions
@@ -29562,7 +28093,7 @@ p5.prototype.append = function(array, value) {
  * @param {Number} [srcPosition] starting position in the source Array
  * @param {Array}  dst           the destination Array
  * @param {Number} [dstPosition] starting position in the destination Array
- * @param {Number} [length]      number of Array elements to be copied
+ * @param {Nimber} [length]      number of Array elements to be copied
  *
  * @example
  *  <div class="norender"><code>
@@ -29756,7 +28287,7 @@ p5.prototype.shuffle = function(arr, bool) {
  *   print(words); // ["banana", "apple", "pear", "lime"]
  *   var count = 4; // length of array
  *
- *   words = sort(words, count);
+ *   sort(words, count);
  *   print(words); // ["apple", "banana", "lime", "pear"]
  * }
  * </div></code>
@@ -29766,7 +28297,7 @@ p5.prototype.shuffle = function(arr, bool) {
  *   print(numbers); // [2,6,1,5,14,9,8,12]
  *   var count = 5; // Less than the length of the array
  *
- *   numbers = sort(numbers, count);
+ *   sort(numbers, count);
  *   print(numbers); // [1,2,5,6,14,9,8,12]
  * }
  * </div></code>
@@ -29853,7 +28384,7 @@ p5.prototype.subset = function(list, start, count) {
 
 module.exports = p5;
 
-},{"../core/core":48}],85:[function(_dereq_,module,exports){
+},{"../core/core":48}],84:[function(_dereq_,module,exports){
 /**
  * @module Data
  * @submodule Conversion
@@ -30114,7 +28645,7 @@ p5.prototype.unhex = function(n) {
 
 module.exports = p5;
 
-},{"../core/core":48}],86:[function(_dereq_,module,exports){
+},{"../core/core":48}],85:[function(_dereq_,module,exports){
 /**
  * @module Data
  * @submodule String Functions
@@ -30597,7 +29128,7 @@ p5.prototype.splitTokens = function() {
  * and tab, this function also removes the Unicode "nbsp" character.
  *
  * @method trim
- * @param  {String|Array} str a String or Array of Strings to be trimmed
+ * @param  {String|Array} [str] a String or Array of Strings to be trimmed
  * @return {String|Array}       a trimmed String or Array of Strings
  * @example
  * <div>
@@ -30617,7 +29148,7 @@ p5.prototype.trim = function(str) {
 
 module.exports = p5;
 
-},{"../core/core":48}],87:[function(_dereq_,module,exports){
+},{"../core/core":48}],86:[function(_dereq_,module,exports){
 /**
  * @module Input
  * @submodule Time & Date
@@ -30638,8 +29169,8 @@ var p5 = _dereq_('../core/core');
  * @example
  * <div>
  * <code>
- * var d = day();
- * text("Current day: \n" + d, 5, 50);
+ * var day = day();
+ * text("Current day: \n" + day, 5, 50);
  * </code>
  * </div>
  */
@@ -30656,8 +29187,8 @@ p5.prototype.day = function() {
  * @example
  * <div>
  * <code>
- * var h = hour();
- * text("Current hour:\n" + h, 5, 50);
+ * var hour = hour();
+ * text("Current hour:\n" + hour, 5, 50);
  * </code>
  * </div>
  */
@@ -30674,8 +29205,8 @@ p5.prototype.hour = function() {
  * @example
  * <div>
  * <code>
- * var m = minute();
- * text("Current minute: \n" + m, 5, 50);
+ * var minute = minute();
+ * text("Current minute: \n" + minute, 5, 50);
  * </code>
  * </div>
  */
@@ -30711,8 +29242,8 @@ p5.prototype.millis = function() {
  * @example
  * <div>
  * <code>
- * var m = month();
- * text("Current month: \n" + m, 5, 50);
+ * var month = month();
+ * text("Current month: \n" + month, 5, 50);
  * </code>
  * </div>
  */
@@ -30729,8 +29260,8 @@ p5.prototype.month = function() {
  * @example
  * <div>
  * <code>
- * var s = second();
- * text("Current second: \n" + s, 5, 50);
+ * var second = second();
+ * text("Current second: \n" + second, 5, 50);
  * </code>
  * </div>
  */
@@ -30747,8 +29278,8 @@ p5.prototype.second = function() {
  * @example
  * <div>
  * <code>
- * var y = year();
- * text("Current year: \n" + y, 5, 50);
+ * var year = year();
+ * text("Current year: \n" + year, 5, 50);
  * </code>
  * </div>
  */

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -892,7 +892,29 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 0
   */
-  this.rotation = 0;
+  Object.defineProperty(this, 'rotation', {
+    enumerable: true,
+    get: function() {
+      return this.rotation_;
+    },
+    set: function(value) {
+      this.rotation_ = value;
+      if (this.rotateToDirection) {
+        this.setSpeed(this.getSpeed(), value);
+      }
+    }
+  });
+
+  /**
+  * Internal rotation variable (expressed in degrees).
+  * Note: external callers access this through the rotation property above.
+  *
+  * @private
+  * @property rotation_
+  * @type {Number}
+  * @default 0
+  */
+  this.rotation_ = 0;
 
   /**
   * Rotation change in degrees per frame of thevisual element (image or animation)
@@ -906,8 +928,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
 
   /**
-  * Automatically set the rotation of the visual element
-  * (image or animation) to the sprite's movement direction.
+  * Automatically lock the rotation property of the visual element
+  * (image or animation) to the sprite's movement direction and vice versa.
   *
   * @property rotateToDirection
   * @type {Boolean}
@@ -1115,10 +1137,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
       if(this.maxSpeed !== -1)
         this.limitSpeed(this.maxSpeed);
 
-      if(this.rotateToDirection)
-        this.rotation = this.getDirection();
-      else
-        this.rotation += this.rotationSpeed;
+      if(this.rotateToDirection && this.velocity.mag() > 0)
+        this.rotation_ = this.getDirection();
+
+      this.rotation += this.rotationSpeed;
 
       this.position.x += this.velocity.x;
       this.position.y += this.velocity.y;
@@ -1616,13 +1638,25 @@ function Sprite(pInst, _x, _y, _w, _h) {
   /**
   * Set the speed and direction of the sprite.
   * The action overwrites the current velocity.
+  * If direction is not supplied, the current direction is maintained.
+  * If direction is not supplied and there is no current velocity, the current
+  * rotation angle used for the direction.
   *
   * @method setSpeed
-  * @param {Number}  speed Scalar speed to add
-  * @param {Number}  angle Direction in degrees
+  * @param {Number}  speed Scalar speed
+  * @param {Number}  [angle] Direction in degrees
   */
   this.setSpeed = function(speed, angle) {
-    var a = radians(angle);
+    var a;
+    if (typeof angle === 'undefined') {
+      if (this.velocity.x !== 0 || this.velocity.y !== 0) {
+        a = Math.atan2(this.velocity.y, this.velocity.x);
+      } else {
+        a = radians(this.rotation_);
+      }
+    } else {
+      a = radians(angle);
+    }
     this.velocity.x = cos(a)*speed;
     this.velocity.y = sin(a)*speed;
   };

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -895,10 +895,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
   Object.defineProperty(this, 'rotation', {
     enumerable: true,
     get: function() {
-      return this.rotation_;
+      return this._rotation;
     },
     set: function(value) {
-      this.rotation_ = value;
+      this._rotation = value;
       if (this.rotateToDirection) {
         this.setSpeed(this.getSpeed(), value);
       }
@@ -910,11 +910,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * Note: external callers access this through the rotation property above.
   *
   * @private
-  * @property rotation_
+  * @property _rotation
   * @type {Number}
   * @default 0
   */
-  this.rotation_ = 0;
+  this._rotation = 0;
 
   /**
   * Rotation change in degrees per frame of thevisual element (image or animation)
@@ -1138,7 +1138,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
         this.limitSpeed(this.maxSpeed);
 
       if(this.rotateToDirection && this.velocity.mag() > 0)
-        this.rotation_ = this.getDirection();
+        this._rotation = this.getDirection();
 
       this.rotation += this.rotationSpeed;
 
@@ -1652,7 +1652,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       if (this.velocity.x !== 0 || this.velocity.y !== 0) {
         a = Math.atan2(this.velocity.y, this.velocity.x);
       } else {
-        a = radians(this.rotation_);
+        a = radians(this._rotation);
       }
     } else {
       a = radians(angle);


### PR DESCRIPTION
(Previously opened as https://github.com/molleindustria/p5.play/pull/85 - now with additional merges applied)

code.org is using p5.play.js as part of a new computer science curriculum. We would like to change the behavior of the Sprite object's rotateToDirection property to make it lock the rotation property with the velocity angle bi-directionally (the current behavior is to ignore the rotation property in this mode and continually overwrite it with the angle of the velocity vector). This change is accomplished by implementing a custom "setter" for the rotation property that updates the velocity vector when rotateToDirection is true. The internal (private) storage for the rotation property value is now stored in the rotation_ property.

In addition, we would like to change the second parameter of the Sprite object's setSpeed function (the angle) to be optional, so that the speed alone can be changed. (Omitting the angle parameter is essentially the same as calling sprite.setSpeed(<new value>, sprite.getDirection()), except we have elected to default the angle to the rotation property when the velocity vector is 0,0). This allows the student to enable rotateToDirection, then freely call setSpeed() with a speed parameter only and set rotation to change direction. The sprite can be stopped in this mode by calling setSpeed(0) and restarted along the same angle by calling setSpeed() with a positive speed value.

The rotationSpeed property will now continue to be respected even while in rotateToDirection mode. To preserve the previous behavior of always locking the rotation property to the velocity angle, the rotation property should not be modified and the rotationSpeed property should be set to zero.