### PR TITLE
Create internal copy of width and height in Sprite class

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1015,11 +1015,49 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * Width of the sprite's current image.
   * If no images or animations are set it's the width of the
   * placeholder rectangle.
+  * Used internally to make calculations.
+  *
+  * @property internalWidth
+  * @type {Number}
+  * @default 100
+  */
+
+  this.internalWidth = _w;
+
+  /**
+  * Height of the sprite's current image.
+  * If no images or animations are set it's the height of the
+  * placeholder rectangle.
+  * Used internally to make calculations.
+  *
+  * @property internalHeight
+  * @type {Number}
+  * @default 100
+  */
+
+  this.internalHeight = _h;
+
+  /**
+  * Width of the sprite's current image.
+  * If no images or animations are set it's the width of the
+  * placeholder rectangle.
   *
   * @property width
   * @type {Number}
   * @default 100
   */
+
+  Object.defineProperty(this, 'width', {
+    enumerable: true,
+    configurable: true,
+    get: function() {
+      return this.internalWidth;
+    },
+    set: function(value) {
+      this.internalWidth = value;
+    }
+  });
+
   if(_w === undefined)
     this.width = 100;
   else
@@ -1034,6 +1072,18 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 100
   */
+
+  Object.defineProperty(this, 'height', {
+    enumerable: true,
+    configurable: true,
+    get: function() {
+      return this.internalHeight;
+    },
+    set: function(value) {
+      this.internalHeight = value;
+    }
+  });
+
   if(_h === undefined)
     this.height = 100;
   else
@@ -1048,7 +1098,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 100
   */
-  this.originalWidth = this.width;
+  this.originalWidth = this.internalWidth;
 
   /**
   * Unscaled height of the sprite
@@ -1059,7 +1109,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 100
   */
-  this.originalHeight = this.height;
+  this.originalHeight = this.internalHeight;
 
   /**
   * True if the sprite has been removed.
@@ -1172,17 +1222,17 @@ function Sprite(pInst, _x, _y, _w, _h) {
         {
         this.collider = this.getBoundingBox();
         this.colliderType = 'image';
-        this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-        this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+        this.internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
+        this.internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
         //quadTree.insert(this);
         }
 
         //update size and collider
-        if(animations[currentAnimation].frameChanged || this.width === undefined || this.height === undefined)
+        if(animations[currentAnimation].frameChanged || this.internalWidth === undefined || this.internalHeight === undefined)
         {
         //this.collider = this.getBoundingBox();
-        this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-        this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+        this.internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
+        this.internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
         }
       }
 
@@ -1217,11 +1267,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
           }
         else if(this.colliderType === 'image')
           {
-          this.collider.extents.x = this.width * abs(cos(t)) +
-          this.height * abs(sin(t));
+          this.collider.extents.x = this.internalWidth * abs(cos(t)) +
+          this.internalHeight * abs(sin(t));
 
-          this.collider.extents.y = this.width * abs(sin(t)) +
-          this.height * abs(cos(t));
+          this.collider.extents.y = this.internalWidth * abs(sin(t)) +
+          this.internalHeight * abs(cos(t));
           }
         }
 
@@ -1283,8 +1333,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(animations[currentAnimation] && (animations[currentAnimation].getWidth() !== 1 && animations[currentAnimation].getHeight() !== 1))
     {
       this.collider = this.getBoundingBox();
-      this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-      this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+      this.internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
+      this.internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
       //quadTree.insert(this);
       this.colliderType = 'image';
       //print("IMAGE COLLIDER ADDED");
@@ -1296,7 +1346,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     }
     else //get the with and height defined at the creation
     {
-      this.collider = new AABB(pInst, this.position, createVector(this.width, this.height));
+      this.collider = new AABB(pInst, this.position, createVector(this.internalWidth, this.internalHeight));
       //quadTree.insert(this);
       this.colliderType = 'default';
     }
@@ -1559,7 +1609,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     {
       noStroke();
       fill(this.shapeColor);
-      rect(0, 0, this.width, this.height);
+      rect(0, 0, this.internalWidth, this.internalHeight);
     }
   };
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1039,7 +1039,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
   /*
    * _internalWidth and _internalHeight are used for all p5.play
-   * calculations, but width and height can be exteneded. For example,
+   * calculations, but width and height can be extended. For example,
    * you may want users to always get and set a scaled width:
       Object.defineProperty(this, 'width', {
         enumerable: true,

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1011,31 +1011,31 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this.mouseIsPressed = false;
 
-  /**
+  /*
   * Width of the sprite's current image.
   * If no images or animations are set it's the width of the
   * placeholder rectangle.
-  * Used internally to make calculations.
+  * Used internally to make calculations and draw the sprite.
   *
-  * @property internalWidth
+  * @private
+  * @property _internalWidth
   * @type {Number}
   * @default 100
   */
+  this._internalWidth = _w;
 
-  this.internalWidth = _w;
-
-  /**
+  /*
   * Height of the sprite's current image.
   * If no images or animations are set it's the height of the
   * placeholder rectangle.
-  * Used internally to make calculations.
+  * Used internally to make calculations and draw the sprite.
   *
-  * @property internalHeight
+  * @private
+  * @property _internalHeight
   * @type {Number}
   * @default 100
   */
-
-  this.internalHeight = _h;
+  this._internalHeight = _h;
 
   /**
   * Width of the sprite's current image.
@@ -1046,15 +1046,14 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 100
   */
-
   Object.defineProperty(this, 'width', {
     enumerable: true,
     configurable: true,
     get: function() {
-      return this.internalWidth;
+      return this._internalWidth;
     },
     set: function(value) {
-      this.internalWidth = value;
+      this._internalWidth = value;
     }
   });
 
@@ -1072,15 +1071,14 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 100
   */
-
   Object.defineProperty(this, 'height', {
     enumerable: true,
     configurable: true,
     get: function() {
-      return this.internalHeight;
+      return this._internalHeight;
     },
     set: function(value) {
-      this.internalHeight = value;
+      this._internalHeight = value;
     }
   });
 
@@ -1098,7 +1096,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 100
   */
-  this.originalWidth = this.internalWidth;
+  this.originalWidth = this._internalWidth;
 
   /**
   * Unscaled height of the sprite
@@ -1109,7 +1107,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * @type {Number}
   * @default 100
   */
-  this.originalHeight = this.internalHeight;
+  this.originalHeight = this._internalHeight;
 
   /**
   * True if the sprite has been removed.
@@ -1222,17 +1220,17 @@ function Sprite(pInst, _x, _y, _w, _h) {
         {
         this.collider = this.getBoundingBox();
         this.colliderType = 'image';
-        this.internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
-        this.internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
+        this._internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
+        this._internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
         //quadTree.insert(this);
         }
 
         //update size and collider
-        if(animations[currentAnimation].frameChanged || this.internalWidth === undefined || this.internalHeight === undefined)
+        if(animations[currentAnimation].frameChanged || this._internalWidth === undefined || this._internalHeight === undefined)
         {
         //this.collider = this.getBoundingBox();
-        this.internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
-        this.internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
+        this._internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
+        this._internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
         }
       }
 
@@ -1267,11 +1265,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
           }
         else if(this.colliderType === 'image')
           {
-          this.collider.extents.x = this.internalWidth * abs(cos(t)) +
-          this.internalHeight * abs(sin(t));
+          this.collider.extents.x = this._internalWidth * abs(cos(t)) +
+          this._internalHeight * abs(sin(t));
 
-          this.collider.extents.y = this.internalWidth * abs(sin(t)) +
-          this.internalHeight * abs(cos(t));
+          this.collider.extents.y = this._internalWidth * abs(sin(t)) +
+          this._internalHeight * abs(cos(t));
           }
         }
 
@@ -1333,8 +1331,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(animations[currentAnimation] && (animations[currentAnimation].getWidth() !== 1 && animations[currentAnimation].getHeight() !== 1))
     {
       this.collider = this.getBoundingBox();
-      this.internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
-      this.internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
+      this._internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
+      this._internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
       //quadTree.insert(this);
       this.colliderType = 'image';
       //print("IMAGE COLLIDER ADDED");
@@ -1346,7 +1344,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     }
     else //get the with and height defined at the creation
     {
-      this.collider = new AABB(pInst, this.position, createVector(this.internalWidth, this.internalHeight));
+      this.collider = new AABB(pInst, this.position, createVector(this._internalWidth, this._internalHeight));
       //quadTree.insert(this);
       this.colliderType = 'default';
     }
@@ -1609,7 +1607,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     {
       noStroke();
       fill(this.shapeColor);
-      rect(0, 0, this.internalWidth, this.internalHeight);
+      rect(0, 0, this._internalWidth, this._internalHeight);
     }
   };
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1037,6 +1037,22 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this._internalHeight = _h;
 
+  /*
+   * _internalWidth and _internalHeight are used for all p5.play
+   * calculations, but width and height can be exteneded. For example,
+   * you may want users to always get and set a scaled width:
+      Object.defineProperty(this, 'width', {
+        enumerable: true,
+        configurable: true,
+        get: function() {
+          return this._internalWidth * this.scale;
+        },
+        set: function(value) {
+          this._internalWidth = value / this.scale;
+        }
+      });
+   */
+
   /**
   * Width of the sprite's current image.
   * If no images or animations are set it's the width of the


### PR DESCRIPTION
cc: @islemaster 

Create an internal copy of width and height in Sprite class to allow for modifications to with and height property. This should have no affects on p5.play functionality, but for Code Studio Game Lab, we want to change the way students interact with width, height and scale. This PR, along with this Game Lab PR (https://github.com/code-dot-org/code-dot-org/pull/9387) create that functionality. 

In Game Lab, `width` and `height` properties should work like this:
* Sprite starts out as 100x100
* User sets animation for sprite, which is 150, 100.  [sprite.scale: 1; sprite.width: 150; sprite.height: 100]
* User sets scale of sprite to 2.  This updates the width/height. [sprite.scale: 2; sprite.width: 300; sprite.height: 200]
* User sets the sprite width to 260.  [sprite.scale: 2; sprite.width: 260; sprite.height: 200]
* User sets scale of sprite back to 1.  [sprite.scale: 1; sprite.width: 130; sprite.height: 100]
* User sets animation for sprite to something else (say a 50x50 image) and sets the scale again to 2.  [sprite.scale: 2; sprite.width:100; sprite.height:100]
* User sets animation back to the first one. [sprite.scale: 2; sprite.width:300; sprite.height:200]