### PR TITLE
Update collision calculations to use current width and height

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1276,10 +1276,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
           }
         else if(this.colliderType === 'default')
           {
-          this.collider.extents.x = this.width * abs(this.scale) * abs(cos(t)) +
-          this.height * abs(this.scale) * abs(sin(t));
-          this.collider.extents.y = this.width * abs(this.scale) * abs(sin(t)) +
-          this.height * abs(this.scale) * abs(cos(t));
+          this.collider.extents.x = this._internalWidth * abs(this.scale) * abs(cos(t)) +
+          this._internalHeight * abs(this.scale) * abs(sin(t));
+          this.collider.extents.y = this._internalWidth * abs(this.scale) * abs(sin(t)) +
+          this._internalHeight * abs(this.scale) * abs(cos(t));
           }
         else if(this.colliderType === 'image')
           {

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -818,8 +818,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * It can either be an Axis Aligned Bounding Box (a non-rotated rectangle)
   * or a circular collider.
   * If the sprite is checked for collision, bounce, overlapping or mouse events the
-  * collider is automatically created from the width and height parameter passed at the
-  * creation of the sprite or the from the image dimension in case of animate sprites
+  * collider is automatically created from the width and height
+  * of the sprite or from the image dimension in case of animate sprites
   *
   * You can set a custom collider with Sprite.setCollider
   *
@@ -1210,10 +1210,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
           }
         else if(this.colliderType === 'default')
           {
-          this.collider.extents.x = this.originalWidth * abs(this.scale) * abs(cos(t)) +
-          this.originalHeight * abs(this.scale) * abs(sin(t));
-          this.collider.extents.y = this.originalWidth * abs(this.scale) * abs(sin(t)) +
-          this.originalHeight * abs(this.scale) * abs(cos(t));
+          this.collider.extents.x = this.width * abs(this.scale) * abs(cos(t)) +
+          this.height * abs(this.scale) * abs(sin(t));
+          this.collider.extents.y = this.width * abs(this.scale) * abs(sin(t)) +
+          this.height * abs(this.scale) * abs(cos(t));
           }
         else if(this.colliderType === 'image')
           {


### PR DESCRIPTION
Updates collisions with a default collider to use the current width and height. 

@islemaster @toolness  This fixes a case where colliders weren't updating properly when a sprite's width/height got changed by a user. Also `originalHeight` and `originalWidth` are no longer used internally. Should we go ahead and get rid of it or just keep it incase others are using it? Thoughts? 



For the "Collisions - overlap, collide, displace" example, I removed the animations and set the rectangles to have a new width and height: `asterisk.width = 200;` and `cloud.height = 120;`

Before fix: In debug mode you can see that the collision rectangle remains at 100x100 which is the original width set for the sprite, instead of updating to 200x100.
<img width="572" alt="screen shot 2016-07-12 at 5 24 06 pm" src="https://cloud.githubusercontent.com/assets/4640747/16787967/7cc58bf2-4855-11e6-9e54-fd780ff217b4.png">

After fix: Collision rectangle matches the sprite size.
<img width="595" alt="screen shot 2016-07-12 at 5 22 03 pm" src="https://cloud.githubusercontent.com/assets/4640747/16787942/43f578b4-4855-11e6-8e1d-e3fecd4012ab.png">

Note - I think once PR (https://github.com/molleindustria/p5.play/pull/97) gets updated, we should be using the `_internalWidth` and `_internalHeight` to update collision rectangles.