### PR TITLE
Fix width and height accesses from frames for animations

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3408,7 +3408,7 @@ function Animation(pInst) {
   else if (frameArguments.length === 1 && (frameArguments[0] instanceof SpriteSheet))
   {
     this.spriteSheet = frameArguments[0];
-    this.images = this.spriteSheet.frames;
+    this.images = this.spriteSheet.frames.map(function (f) {return f.frame;});
   }
   else if(frameArguments.length !== 0)//arbitrary list of images
   {
@@ -3435,11 +3435,8 @@ function Animation(pInst) {
 
     if (this.spriteSheet) {
       myClone.spriteSheet = this.spriteSheet.clone();
-      myClone.images = myClone.spriteSheet.frames;
-    } else {
-      for (var i = 0; i < this.images.length; i++)
-        myClone.images.push(this.images[i]);
     }
+    myClone.images = this.images.slice();
 
     myClone.offX = this.offX;
     myClone.offY = this.offY;
@@ -3486,7 +3483,7 @@ function Animation(pInst) {
       if(this.images[frame] !== undefined)
       {
         if (this.spriteSheet) {
-          var frame_info = this.images[frame].frame;
+          var frame_info = this.images[frame];
           pInst.image(this.spriteSheet.image, frame_info.x, frame_info.y, frame_info.width,
             frame_info.height, this.offX, this.offY, frame_info.width, frame_info.height);
         } else {

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3408,7 +3408,9 @@ function Animation(pInst) {
   else if (frameArguments.length === 1 && (frameArguments[0] instanceof SpriteSheet))
   {
     this.spriteSheet = frameArguments[0];
-    this.images = this.spriteSheet.frames.map(function (f) {return f.frame;});
+    this.images = this.spriteSheet.frames.map( function(f) {
+      return f.frame;
+    });
   }
   else if(frameArguments.length !== 0)//arbitrary list of images
   {


### PR DESCRIPTION
@islemaster @toolness 
Animations created with spritesheets were returning NaN for `width` and `height`. This fixes it so that users can access a sprite's height and width.

What's next: write some unit tests for animations. I'll submit another PR with these.