### PR TITLE
Upgrade ESLint dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: node_js
+node_js: 4

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -128,7 +128,9 @@ var round = p5.prototype.round;
 * @type {Group}
 */
 
-defineLazyP5Property('allSprites', function() { return new Group(); });
+defineLazyP5Property('allSprites', function() {
+  return new Group();
+});
 
 p5.prototype.spriteUpdate = true;
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "A p5.js library for the creation of games and playthings.",
   "dependencies": {},
   "devDependencies": {
-    "eslint": ">=2.5.3 <2.10.0",
+    "eslint": "^3.1.0",
     "http-server": "^0.9.0",
     "mocha-phantomjs": "^4.0.1",
     "yuidocjs": "^0.10.0"
+  },
+  "engines": {
+    "node" : ">=4.0.0"
   },
   "scripts": {
     "docs": "yuidoc .",


### PR DESCRIPTION
Fixes #93.

Update from `>=2.5.3 <2.10.0` to `^3.1.0` which is the latest version.  The major breaking change with this update is [dropping support](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-3.0.0.md#dropping-support-for-nodejs--4) for Node.js < 4 which shouldn't be an issue for this repo (as ESLint points out, Node 4 is the current LTS version).  I've added the engines field in package.json to document the dependency on Node >= 4.

Fixes the one new linting violation caught after the upgrade (and I'm actually surprised this one wasn't caught _before_ it).