### PR TITLE
Fix width and height overriding

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1129,23 +1129,21 @@ function Sprite(pInst, _x, _y, _w, _h) {
     //the animation wasn't loaded. if the animation is not a 1x1 image
     //it means it just finished loading
     if(this.colliderType === 'default' &&
-      animations[currentAnimation].getWidth() !== 1 &&
-       animations[currentAnimation].getHeight() !== 1
-      )
+      animations[currentAnimation].getWidth() !== 1 && animations[currentAnimation].getHeight() !== 1)
     {
-    this.collider = this.getBoundingBox();
-    this.colliderType = 'image';
-    this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
-    this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
-    //quadTree.insert(this);
+      this.collider = this.getBoundingBox();
+      this.colliderType = 'image';
+      this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+      this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
+      //quadTree.insert(this);
     }
 
     //update size and collider
     if(animations[currentAnimation].frameChanged || this.width === undefined || this.height === undefined)
     {
-    //this.collider = this.getBoundingBox();
-    this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
-    this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
+      //this.collider = this.getBoundingBox();
+      this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+      this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
     }
   };
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1135,8 +1135,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     {
     this.collider = this.getBoundingBox();
     this.colliderType = 'image';
-    this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-    this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+    this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+    this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
     //quadTree.insert(this);
     }
 
@@ -1144,8 +1144,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(animations[currentAnimation].frameChanged || this.width === undefined || this.height === undefined)
     {
     //this.collider = this.getBoundingBox();
-    this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-    this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+    this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+    this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
     }
   };
 
@@ -1210,18 +1210,18 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
         if(this.colliderType === 'custom')
           {
-          this.collider.extents.x = this.collider.originalExtents.x * abs(this.scale) * abs(cos(t)) +
-          this.collider.originalExtents.y * abs(this.scale) * abs(sin(t));
+          this.collider.extents.x = this.collider.originalExtents.x * abs(this._getScaleX()) * abs(cos(t)) +
+          this.collider.originalExtents.y * abs(this._getScaleY()) * abs(sin(t));
 
-          this.collider.extents.y = this.collider.originalExtents.x * abs(this.scale) * abs(sin(t)) +
-          this.collider.originalExtents.y * abs(this.scale) * abs(cos(t));
+          this.collider.extents.y = this.collider.originalExtents.x * abs(this._getScaleX()) * abs(sin(t)) +
+          this.collider.originalExtents.y * abs(this._getScaleY()) * abs(cos(t));
           }
         else if(this.colliderType === 'default')
           {
-          this.collider.extents.x = this.originalWidth * abs(this.scale) * abs(cos(t)) +
-          this.originalHeight * abs(this.scale) * abs(sin(t));
-          this.collider.extents.y = this.originalWidth * abs(this.scale) * abs(sin(t)) +
-          this.originalHeight * abs(this.scale) * abs(cos(t));
+          this.collider.extents.x = this.originalWidth * abs(this._getScaleX()) * abs(cos(t)) +
+          this.originalHeight * abs(this._getScaleY()) * abs(sin(t));
+          this.collider.extents.y = this.originalWidth * abs(this._getScaleX()) * abs(sin(t)) +
+          this.originalHeight * abs(this._getScaleY()) * abs(cos(t));
           }
         else if(this.colliderType === 'image')
           {
@@ -1291,8 +1291,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(animations[currentAnimation] && (animations[currentAnimation].getWidth() !== 1 && animations[currentAnimation].getHeight() !== 1))
     {
       this.collider = this.getBoundingBox();
-      this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-      this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+      this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+      this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
       //quadTree.insert(this);
       this.colliderType = 'image';
       //print("IMAGE COLLIDER ADDED");
@@ -1434,8 +1434,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
    */
   this.getBoundingBox = function() {
 
-    var w = animations[currentAnimation].getWidth()*abs(this.scale);
-    var h = animations[currentAnimation].getHeight()*abs(this.scale);
+    var w = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+    var h = animations[currentAnimation].getHeight()*abs(this._getScaleY());
 
     //if the bounding box is 1x1 the image is not loaded
     //potential issue with actual 1x1 images
@@ -1482,6 +1482,25 @@ function Sprite(pInst, _x, _y, _w, _h) {
       return dirY;
   };
 
+  /*
+   * Returns the value the sprite should be scaled in the X direction.
+   * Used to calculate rendering and collisions.
+   * @private
+   */
+  this._getScaleX = function()
+  {
+    return this.scale;
+  };
+
+  /*
+   * Returns the value the sprite should be scaled in the Y direction.
+   * Used to calculate rendering and collisions.
+   * @private
+   */
+  this._getScaleY = function()
+  {
+    return this.scale;
+  };
 
   /**
    * Manages the positioning, scale and rotation of the sprite
@@ -1503,7 +1522,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       imageMode(CENTER);
 
       translate(this.position.x, this.position.y);
-      scale(this.scale*dirX, this.scale*dirY);
+      scale(this._getScaleX()*dirX, this._getScaleY()*dirY);
       if (pInst._angleMode === pInst.RADIANS) {
         rotate(radians(this.rotation));
       } else {
@@ -1814,8 +1833,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
       newAnimation.isSpriteAnimation = true;
 
-      this.width = newAnimation.getWidth()*abs(this.scale);
-      this.height = newAnimation.getHeight()*abs(this.scale);
+      this.width = newAnimation.getWidth()*abs(this._getScaleX());
+      this.height = newAnimation.getHeight()*abs(this._getScaleY());
 
       return newAnimation;
     }
@@ -1835,8 +1854,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
       }
       anim.isSpriteAnimation = true;
 
-      this.width = anim.getWidth()*abs(this.scale);
-      this.height = anim.getHeight()*abs(this.scale);
+      this.width = anim.getWidth()*abs(this._getScaleX());
+      this.height = anim.getHeight()*abs(this._getScaleY());
 
       return anim;
     }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1199,8 +1199,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     {
       this.collider = this.getBoundingBox();
       this.colliderType = 'image';
-      this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
-      this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
+      this._internalWidth = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+      this._internalHeight = animations[currentAnimation].getHeight()*abs(this._getScaleY());
       //quadTree.insert(this);
     }
 
@@ -1208,8 +1208,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(animations[currentAnimation].frameChanged || this.width === undefined || this.height === undefined)
     {
       //this.collider = this.getBoundingBox();
-      this.width = animations[currentAnimation].getWidth()*abs(this._getScaleX());
-      this.height = animations[currentAnimation].getHeight()*abs(this._getScaleY());
+      this._internalWidth = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+      this._internalHeight = animations[currentAnimation].getHeight()*abs(this._getScaleY());
     }
   };
 
@@ -1897,8 +1897,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
       newAnimation.isSpriteAnimation = true;
 
-      this.width = newAnimation.getWidth()*abs(this._getScaleX());
-      this.height = newAnimation.getHeight()*abs(this._getScaleY());
+      this._internalWidth = newAnimation.getWidth()*abs(this._getScaleX());
+      this._internalHeight = newAnimation.getHeight()*abs(this._getScaleY());
 
       return newAnimation;
     }
@@ -1918,8 +1918,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
       }
       anim.isSpriteAnimation = true;
 
-      this.width = anim.getWidth()*abs(this._getScaleX());
-      this.height = anim.getHeight()*abs(this._getScaleY());
+      this._internalWidth = anim.getWidth()*abs(this._getScaleX());
+      this._internalHeight = anim.getHeight()*abs(this._getScaleY());
 
       return anim;
     }
@@ -3794,22 +3794,33 @@ function Animation(pInst) {
 
   /**
   * Returns the current frame width in pixels.
+  * If there is no image loaded, returns 1.
   *
   * @method getWidth
   * @return {Number} Frame width
   */
   this.getWidth = function() {
-    return this.images[frame].width;
+    if (this.images[frame]) {
+      return this.images[frame].width;
+    } else {
+      return 1;
+    }
+    
   };
 
   /**
   * Returns the current frame height in pixels.
+  * If there is no image loaded, returns 1.
   *
   * @method getHeight
   * @return {Number} Frame height
   */
   this.getHeight = function() {
-    return this.images[frame].height;
+    if (this.images[frame]) {
+      return this.images[frame].height;
+    } else {
+      return 1;
+    }
   };
 
 }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1120,6 +1120,35 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this.animation = undefined;
 
+  /*
+   * @private
+   * Keep animation properties in sync with how the animation changes.
+   */
+  this._syncAnimationSizes = function() {
+    //has an animation but the collider is still default
+    //the animation wasn't loaded. if the animation is not a 1x1 image
+    //it means it just finished loading
+    if(this.colliderType === 'default' &&
+      animations[currentAnimation].getWidth() !== 1 &&
+       animations[currentAnimation].getHeight() !== 1
+      )
+    {
+    this.collider = this.getBoundingBox();
+    this.colliderType = 'image';
+    this.width = animations[currentAnimation].getWidth()*abs(this.scale);
+    this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+    //quadTree.insert(this);
+    }
+
+    //update size and collider
+    if(animations[currentAnimation].frameChanged || this.width === undefined || this.height === undefined)
+    {
+    //this.collider = this.getBoundingBox();
+    this.width = animations[currentAnimation].getWidth()*abs(this.scale);
+    this.height = animations[currentAnimation].getHeight()*abs(this.scale);
+    }
+  };
+
   /**
   * Updates the sprite.
   * Called automatically at the beginning of the draw cycle.
@@ -1162,28 +1191,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
         //update it
         animations[currentAnimation].update();
 
-        //has an animation but the collider is still default
-        //the animation wasn't loaded. if the animation is not a 1x1 image
-        //it means it just finished loading
-        if(this.colliderType === 'default' &&
-          animations[currentAnimation].getWidth() !== 1 &&
-           animations[currentAnimation].getHeight() !== 1
-          )
-        {
-        this.collider = this.getBoundingBox();
-        this.colliderType = 'image';
-        this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-        this.height = animations[currentAnimation].getHeight()*abs(this.scale);
-        //quadTree.insert(this);
-        }
-
-        //update size and collider
-        if(animations[currentAnimation].frameChanged || this.width === undefined || this.height === undefined)
-        {
-        //this.collider = this.getBoundingBox();
-        this.width = animations[currentAnimation].getWidth()*abs(this.scale);
-        this.height = animations[currentAnimation].getHeight()*abs(this.scale);
-        }
+        this._syncAnimationSizes();
       }
 
       //a collider is created either manually with setCollider or
@@ -1806,6 +1814,9 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
       newAnimation.isSpriteAnimation = true;
 
+      this.width = newAnimation.getWidth()*abs(this.scale);
+      this.height = newAnimation.getHeight()*abs(this.scale);
+
       return newAnimation;
     }
     else
@@ -1823,6 +1834,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
         this.animation = anim;
       }
       anim.isSpriteAnimation = true;
+
+      this.width = anim.getWidth()*abs(this.scale);
+      this.height = anim.getHeight()*abs(this.scale);
+
       return anim;
     }
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3805,7 +3805,6 @@ function Animation(pInst) {
     } else {
       return 1;
     }
-    
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1355,8 +1355,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(animations[currentAnimation] && (animations[currentAnimation].getWidth() !== 1 && animations[currentAnimation].getHeight() !== 1))
     {
       this.collider = this.getBoundingBox();
-      this._internalWidth = animations[currentAnimation].getWidth()*abs(this.scale);
-      this._internalHeight = animations[currentAnimation].getHeight()*abs(this.scale);
+      this._internalWidth = animations[currentAnimation].getWidth()*abs(this._getScaleX());
+      this._internalHeight = animations[currentAnimation].getHeight()*abs(this._getScaleY());
       //quadTree.insert(this);
       this.colliderType = 'image';
       //print("IMAGE COLLIDER ADDED");

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -76,5 +76,55 @@ describe('Sprite', function() {
       checkDirectionForVelocity([1, 1], 45);
       checkDirectionForVelocity([0, 1], 90);
     });
+
+  });
+
+  describe('demension updating when animation changes', function() {
+    it('animation width and height get inherited from frame', function() {
+      var image = new p5.Image(100, 100, pInst);
+      var frames = [
+        {name: 0, frame: {x: 0, y: 0, width: 30, height: 30}}
+      ];
+      var sheet = new pInst.SpriteSheet(image, frames);
+      var animation = new pInst.Animation(sheet);
+
+      var sprite = pInst.createSprite(0, 0);
+      sprite.addAnimation('label', animation);
+
+      expect(sprite.width).to.equal(30);
+      expect(sprite.height).to.equal(30);
+    });
+
+    it('updates the width and height property when frames are different sizes', function() {
+      var image = new p5.Image(100, 100, pInst);
+      var frames = [
+        {name: 0, frame: {x: 0, y: 0, width: 50, height: 50}},
+        {name: 1, frame: {x: 100, y: 0, width: 40, height: 60}},
+        {name: 2, frame: {x: 0, y: 80, width: 70, height: 30}}
+      ];
+      var sheet = new pInst.SpriteSheet(image, frames);
+      var animation = new pInst.Animation(sheet);
+
+      var sprite = pInst.createSprite(0, 0);
+      sprite.addAnimation('label', animation);
+
+      expect(sprite.width).to.equal(50);
+      expect(sprite.height).to.equal(50);
+
+      // Frame changes after every 4th update because of frame delay.
+      sprite.update();
+      sprite.update();
+      sprite.update();
+      sprite.update();
+      expect(sprite.width).to.equal(40);
+      expect(sprite.height).to.equal(60);
+
+      sprite.update();
+      sprite.update();
+      sprite.update();
+      sprite.update();
+      expect(sprite.width).to.equal(70);
+      expect(sprite.height).to.equal(30);
+    });
   });
 });

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -79,7 +79,7 @@ describe('Sprite', function() {
 
   });
 
-  describe('demension updating when animation changes', function() {
+  describe('dimension updating when animation changes', function() {
     it('animation width and height get inherited from frame', function() {
       var image = new p5.Image(100, 100, pInst);
       var frames = [


### PR DESCRIPTION
@islemaster @toolness Hi! I was running into some issues with using p5.play to modify and get a sprite's width and height when it has an animation. The first item is a bug fix, but I also wanted to increase flexibility of p5.play so that logic could be more easily modified by users of the library so I added a few new functions as well.

- Initialize `width` and `height` when adding an animation
- Factor out updating sizes for animations outside of the update function
- Create `_getScaleX` and `_getScaleY` (currently as getters for scale) which opens the opportunity to have a horizontal scale and a vertical scale that are different.
- Added a test for an animation with frames that have different sizes. The width and height should update when each frame is updated. This happens in the helper `this._syncAnimationSizes` now