### PR TITLE
Tell linter about global mouseIsPressed

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3,6 +3,7 @@ p5.play
 by Paolo Pedercini/molleindustria, 2015
 http://molleindustria.org/
 */
+/* global mouseIsPressed */
 
 (function(root, factory) {
 if (typeof define === 'function' && define.amd)


### PR DESCRIPTION
Just to unblock Travis CI for unrelated changes going in.  See discussion on the change that introduced the global reference to `mouseIsPressed` on https://github.com/molleindustria/p5.play/commit/8151d9b1d7e4923b07956fd9646036536655d23a.