### PR TITLE
Drag fix in instance mode

### DIFF
--- a/examples/mouseEvents.js
+++ b/examples/mouseEvents.js
@@ -3,6 +3,7 @@
 
 var asterisk;
 var ghost;
+var draggedSprite;
 
 function setup() {
   createCanvas(800, 400);
@@ -34,17 +35,28 @@ function setup() {
   asterisk.onMousePressed = function() {
     this.changeAnimation('transform');
     this.animation.goToFrame(this.animation.getLastFrame());
+    if (draggedSprite == null) {
+      draggedSprite = this;
+    }
   };
 
   asterisk.onMouseReleased = function() {
     this.changeAnimation('transform');
     this.animation.goToFrame(0);
+    if (draggedSprite == this) {
+      draggedSprite = null;
+    }
   };
 
 }
 
 function draw() {
   background(255, 255, 255);
+
+  if (draggedSprite != null) {
+    draggedSprite.position.x = mouseX;
+    draggedSprite.position.y = mouseY;
+  }
 
   //if a sprite is mouseActive true I can check if the mouse is over its collider
   //and if the button is pressed

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3,7 +3,6 @@ p5.play
 by Paolo Pedercini/molleindustria, 2015
 http://molleindustria.org/
 */
-/* global mouseIsPressed */
 
 (function(root, factory) {
 if (typeof define === 'function' && define.amd)
@@ -1370,7 +1369,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
           else
             print('Warning: onMousePressed should be a function');
 
-        if(mouseWasPressed && !mouseIsPressed && !this.mouseIsPressed && this.onMouseReleased !== undefined)
+        if(mouseWasPressed && !pInst.mouseIsPressed && !this.mouseIsPressed && this.onMouseReleased !== undefined)
           if(typeof(this.onMouseReleased) === 'function')
             this.onMouseReleased.call(this, this);
           else

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -77,4 +77,31 @@ describe('Sprite', function() {
       checkDirectionForVelocity([0, 1], 90);
     });
   });
+
+  describe('mouse events', function() {
+    it('does not call onMouseReleased on mouse-out if mouse is still down', function() {
+      var sprite = pInst.createSprite(0, 0, 100, 100);
+      sprite.onMouseOver = sinon.spy();
+      sprite.onMouseOut = sinon.spy();
+      sprite.onMousePressed = sinon.spy();
+      sprite.onMouseReleased = sinon.spy();
+      sprite.update();
+      expect(sprite.onMousePressed.called).to.be.false;
+      expect(sprite.onMouseReleased.called).to.be.false;
+
+      pInst.mouseX = 0;
+      pInst.mouseY = 0;
+      pInst.mouseIsPressed = true;
+      sprite.update();
+      expect(sprite.onMousePressed.called).to.be.true;
+      expect(sprite.onMouseReleased.called).to.be.false;
+
+      pInst.mouseX = 200;
+      pInst.mouseY = 0;
+      pInst.mouseIsPressed = true;
+      sprite.update();
+      expect(sprite.onMousePressed.called).to.be.true;
+      expect(sprite.onMouseReleased.called).to.be.false;
+    });
+  });
 });

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -79,29 +79,165 @@ describe('Sprite', function() {
   });
 
   describe('mouse events', function() {
-    it('does not call onMouseReleased on mouse-out if mouse is still down', function() {
-      var sprite = pInst.createSprite(0, 0, 100, 100);
+    var sprite;
+
+    beforeEach(function() {
+      // Create a sprite with centered at 50,50 with size 100,100.
+      // Its default collider picks up anything from 1,1 to 99,99.
+      sprite = pInst.createSprite(50, 50, 100, 100);
       sprite.onMouseOver = sinon.spy();
       sprite.onMouseOut = sinon.spy();
       sprite.onMousePressed = sinon.spy();
       sprite.onMouseReleased = sinon.spy();
-      sprite.update();
-      expect(sprite.onMousePressed.called).to.be.false;
-      expect(sprite.onMouseReleased.called).to.be.false;
+    });
 
-      pInst.mouseX = 0;
-      pInst.mouseY = 0;
+    function moveMouseTo(x, y) {
+      pInst.mouseX = x;
+      pInst.mouseY = y;
+      sprite.update();
+    }
+
+    function moveMouseOver() {
+      moveMouseTo(1, 1);
+    }
+
+    function moveMouseOut() {
+      moveMouseTo(0, 0);
+    }
+
+    function pressMouse() {
       pInst.mouseIsPressed = true;
       sprite.update();
-      expect(sprite.onMousePressed.called).to.be.true;
-      expect(sprite.onMouseReleased.called).to.be.false;
+    }
 
-      pInst.mouseX = 200;
-      pInst.mouseY = 0;
-      pInst.mouseIsPressed = true;
+    function releaseMouse() {
+      pInst.mouseIsPressed = false;
       sprite.update();
-      expect(sprite.onMousePressed.called).to.be.true;
-      expect(sprite.onMouseReleased.called).to.be.false;
+    }
+
+    it('mouseIsOver property represents whether mouse is over collider', function() {
+      moveMouseTo(0, 0);
+      expect(sprite.mouseIsOver).to.be.false;
+      moveMouseTo(1, 1);
+      expect(sprite.mouseIsOver).to.be.true;
+      moveMouseTo(99, 99);
+      expect(sprite.mouseIsOver).to.be.true;
+      moveMouseTo(100, 100);
+      expect(sprite.mouseIsOver).to.be.false;
+    });
+
+    describe('onMouseOver callback', function() {
+      it('calls onMouseOver when the mouse enters the sprite collider', function() {
+        moveMouseOut();
+        expect(sprite.onMouseOver.called).to.be.false;
+        moveMouseOver();
+        expect(sprite.onMouseOver.called).to.be.true;
+      });
+
+      it('does not call onMouseOver when the mouse moves within the sprite collider', function() {
+        moveMouseTo(0, 0);
+        expect(sprite.onMouseOver.callCount).to.equal(0);
+        moveMouseTo(1, 1);
+        expect(sprite.onMouseOver.callCount).to.equal(1);
+        moveMouseTo(2, 2);
+        expect(sprite.onMouseOver.callCount).to.equal(1);
+      });
+
+      it('calls onMouseOver again when the mouse leaves and returns', function() {
+        moveMouseOut();
+        expect(sprite.onMouseOver.callCount).to.equal(0);
+        moveMouseOver();
+        expect(sprite.onMouseOver.callCount).to.equal(1);
+        moveMouseOut();
+        expect(sprite.onMouseOver.callCount).to.equal(1);
+        moveMouseOver();
+        expect(sprite.onMouseOver.callCount).to.equal(2);
+      });
+    });
+
+    describe('onMouseOut callback', function() {
+      it('calls onMouseOut when the mouse leaves the sprite collider', function() {
+        moveMouseOver();
+        expect(sprite.onMouseOut.called).to.be.false;
+        moveMouseOut();
+        expect(sprite.onMouseOut.called).to.be.true;
+      });
+
+      it('does not call onMouseOut when the mouse moves outside the sprite collider', function() {
+        moveMouseTo(0, 0);
+        expect(sprite.onMouseOut.called).to.be.false;
+        moveMouseTo(0, 1);
+        expect(sprite.onMouseOut.called).to.be.false;
+      });
+
+      it('calls onMouseOut again when the mouse returns and leaves', function() {
+        moveMouseOver();
+        expect(sprite.onMouseOut.callCount).to.equal(0);
+        moveMouseOut();
+        expect(sprite.onMouseOut.callCount).to.equal(1);
+        moveMouseOver();
+        expect(sprite.onMouseOut.callCount).to.equal(1);
+        moveMouseOut();
+        expect(sprite.onMouseOut.callCount).to.equal(2);
+      });
+    });
+
+    describe('onMousePressed callback', function() {
+      it('does not call onMousePressed if the mouse was not over the sprite', function() {
+        expect(sprite.mouseIsOver).to.be.false;
+        pressMouse();
+        expect(sprite.onMousePressed.called).to.be.false;
+      });
+
+      it('calls onMousePressed if the mouse was pressed over the sprite', function() {
+        moveMouseOver();
+        pressMouse();
+        expect(sprite.onMousePressed.called).to.be.true;
+      });
+
+      it('calls onMousePressed if the mouse was pressed outside the sprite then dragged over it', function() {
+        pressMouse();
+        moveMouseOver();
+        expect(sprite.onMousePressed.called).to.be.true;
+      });
+    });
+
+    describe('onMouseReleased callback', function() {
+      it('does not call onMouseReleased if the mouse was never pressed over the sprite', function() {
+        expect(sprite.mouseIsOver).to.be.false;
+        pressMouse();
+        releaseMouse();
+        expect(sprite.onMouseReleased.called).to.be.false;
+      });
+
+      it('calls onMouseReleased if the mouse was pressed and released over the sprite', function() {
+        moveMouseOver();
+        pressMouse();
+        releaseMouse();
+        expect(sprite.onMouseReleased.called).to.be.true;
+      });
+
+      it('calls onMouseReleased if the mouse was pressed, moved over the sprite, and then released', function() {
+        pressMouse();
+        moveMouseOver();
+        releaseMouse();
+        expect(sprite.onMouseReleased.called).to.be.true;
+      });
+
+      it('does not call onMouseReleased on mouse-out if mouse is still down', function() {
+        pressMouse();
+        moveMouseOver();
+        moveMouseOut();
+        expect(sprite.onMouseReleased.called).to.be.false;
+      });
+
+      it('does not call onMouseReleased on release if mouse has left sprite', function() {
+        moveMouseOver();
+        pressMouse();
+        moveMouseOut();
+        releaseMouse();
+        expect(sprite.onMouseReleased.called).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
Follow-up to https://github.com/molleindustria/p5.play/commit/8151d9b1d7e4923b07956fd9646036536655d23a that makes that change work for instance mode.

Also adds the related dragging behavior to the mouse events example, and adds tests for Sprite mouse callbacks:
```
    mouse events
      ✓ mouseIsOver property represents whether mouse is over collider 
      onMouseOver callback
        ✓ calls onMouseOver when the mouse enters the sprite collider 
        ✓ does not call onMouseOver when the mouse moves within the sprite collider 
        ✓ calls onMouseOver again when the mouse leaves and returns 
      onMouseOut callback
        ✓ calls onMouseOut when the mouse leaves the sprite collider 
        ✓ does not call onMouseOut when the mouse moves outside the sprite collider 
        ✓ calls onMouseOut again when the mouse returns and leaves 
      onMousePressed callback
        ✓ does not call onMousePressed if the mouse was not over the sprite 
        ✓ calls onMousePressed if the mouse was pressed over the sprite 
        ✓ calls onMousePressed if the mouse was pressed outside the sprite then dragged over it 
      onMouseReleased callback
        ✓ does not call onMouseReleased if the mouse was never pressed over the sprite 
        ✓ calls onMouseReleased if the mouse was pressed and released over the sprite 
        ✓ calls onMouseReleased if the mouse was pressed, moved over the sprite, and then released 
        ✓ does not call onMouseReleased on mouse-out if mouse is still down 
        ✓ does not call onMouseReleased on release if mouse has left sprite 
```