### PR TITLE
Make allSprites group extensible

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -130,7 +130,7 @@ var round = p5.prototype.round;
 */
 
 defineLazyP5Property('allSprites', function() {
-  return new Group();
+  return new p5.prototype.Group();
 });
 
 p5.prototype.spriteUpdate = true;


### PR DESCRIPTION
It's straightforward to extend `Group` by replacing it on the p5 prototype, like this:

```javascript
function MyGroup(originalGroup) {
  var group = originalGroup();
  group.myMethod = function () { /* do something */ };
  return group;
}
p5.prototype.Group = MyGroup.bind(null, p5.prototype.Group);
```

However, the lazy-creation for the `allSprites` group used the original, closed-over `Group` instead of the one on the p5 prototype, meaning it wouldn't use the extended version.  Calling `new p5.prototype.Group()` instead of `new Group()` fixes this, without changing behavior at all for cases where `Group` is left alone.