### PR TITLE
_getScaleX and _getScaleY missing from default collisions

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1282,10 +1282,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
           }
         else if(this.colliderType === 'default')
           {
-          this.collider.extents.x = this._internalWidth * abs(this.scale) * abs(cos(t)) +
-          this._internalHeight * abs(this.scale) * abs(sin(t));
-          this.collider.extents.y = this._internalWidth * abs(this.scale) * abs(sin(t)) +
-          this._internalHeight * abs(this.scale) * abs(cos(t));
+          this.collider.extents.x = this._internalWidth * abs(this._getScaleX()) * abs(cos(t)) +
+          this._internalHeight * abs(this._getScaleY()) * abs(sin(t));
+          this.collider.extents.y = this._internalWidth * abs(this._getScaleX()) * abs(sin(t)) +
+          this._internalHeight * abs(this._getScaleY()) * abs(cos(t));
           }
         else if(this.colliderType === 'image')
           {


### PR DESCRIPTION
Found a missing case in default collisions where we are referencing `scale` instead of `getScaleX()` and `getScaleY()`. (See the 10 lines above where scale functions are called properly).