### PR TITLE
Using println() instead of print()

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -726,7 +726,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   var createVector = pInstBind('createVector');
   var color = pInstBind('color');
   var random = pInstBind('random');
-  var print = pInstBind('print');
+  var print = pInstBind('println');
   var push = pInstBind('push');
   var pop = pInstBind('pop');
   var colorMode = pInstBind('colorMode');

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1425,25 +1425,25 @@ function Sprite(pInst, _x, _y, _w, _h) {
           if(typeof(this.onMouseOver) === 'function')
             this.onMouseOver.call(this, this);
           else
-            print('Warning: onMouseOver should be a function');
+            println('Warning: onMouseOver should be a function');
 
         if(mouseWasOver && !this.mouseIsOver && this.onMouseOut !== undefined)
           if(typeof(this.onMouseOut) === 'function')
             this.onMouseOut.call(this, this);
           else
-            print('Warning: onMouseOut should be a function');
+            println('Warning: onMouseOut should be a function');
 
         if(!mouseWasPressed && this.mouseIsPressed && this.onMousePressed !== undefined)
           if(typeof(this.onMousePressed) === 'function')
             this.onMousePressed.call(this, this);
           else
-            print('Warning: onMousePressed should be a function');
+            println('Warning: onMousePressed should be a function');
 
         if(mouseWasPressed && !pInst.mouseIsPressed && !this.mouseIsPressed && this.onMouseReleased !== undefined)
           if(typeof(this.onMouseReleased) === 'function')
             this.onMouseReleased.call(this, this);
           else
-            print('Warning: onMouseReleased should be a function');
+            println('Warning: onMouseReleased should be a function');
 
       }
 
@@ -1483,7 +1483,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       this.collider = new AABB(pInst, this.position, createVector(width, height), v);
     } else if(type === 'circle') {
       if(arguments.length !== 4) {
-        print('Warning: usage setCollider("circle", offsetX, offsetY, radius)');
+        println('Warning: usage setCollider("circle", offsetX, offsetY, radius)');
       }
 
       this.collider = new CircleCollider(pInst, this.position, width, v);
@@ -1727,7 +1727,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(group instanceof Array)
       group.add(this);
     else
-      print('addToGroup error: '+group+' is not a group');
+      println('addToGroup error: '+group+' is not a group');
   };
 
   /**
@@ -1872,12 +1872,12 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
     if(typeof label !== 'string')
     {
-      print('Sprite.addAnimation error: the first argument must be a label (String)');
+      println('Sprite.addAnimation error: the first argument must be a label (String)');
       return -1;
     }
     else if(arguments.length < 2)
     {
-      print('addAnimation error: you must specify a label and n frame images');
+      println('addAnimation error: you must specify a label and n frame images');
       return -1;
     }
     else if(arguments[1] instanceof Animation)
@@ -1956,7 +1956,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this.changeAnimation = function(label) {
     if(!animations[label])
-      print('changeAnimation error: no animation labeled '+label);
+      println('changeAnimation error: no animation labeled '+label);
     else
     {
       currentAnimation = label;
@@ -1994,7 +1994,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     }
     else
     {
-      print('Error: overlapPixel doesn\'t work with scaled or rotated sprites yet');
+      println('Error: overlapPixel doesn\'t work with scaled or rotated sprites yet');
       //offscreen printing to be implemented bleurch
       return false;
     }
@@ -3523,7 +3523,7 @@ function Animation(pInst) {
   {
     //print("Animation arbitrary mode");
     for (i = 0; i < frameArguments.length; i++) {
-      //print("loading "+fileNames[i]);
+      //println("loading "+fileNames[i]);
       if(frameArguments[i] instanceof p5.Image)
         this.images.push(frameArguments[i]);
       else
@@ -3601,7 +3601,7 @@ function Animation(pInst) {
       }
       else
       {
-        pInst.print('Warning undefined frame '+frame);
+        pInst.println('Warning undefined frame '+frame);
         //this.isActive = false;
       }
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -4,6 +4,12 @@ by Paolo Pedercini/molleindustria, 2015
 http://molleindustria.org/
 */
 
+p5.prototype.print = p5.prototype.println; 
+/*
+  As per the update of p5.js to v0.5.3 print() has been replaced by println() 
+  Please refer to https://github.com/processing/p5.js/issues/1491
+*/
+
 (function(root, factory) {
 if (typeof define === 'function' && define.amd)
 define('p5.play', ['p5'], function(p5) { (factory(p5)); });
@@ -726,7 +732,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   var createVector = pInstBind('createVector');
   var color = pInstBind('color');
   var random = pInstBind('random');
-  var print = pInstBind('println');
+  var print = pInstBind('print');
   var push = pInstBind('push');
   var pop = pInstBind('pop');
   var colorMode = pInstBind('colorMode');
@@ -1425,25 +1431,25 @@ function Sprite(pInst, _x, _y, _w, _h) {
           if(typeof(this.onMouseOver) === 'function')
             this.onMouseOver.call(this, this);
           else
-            println('Warning: onMouseOver should be a function');
+            print('Warning: onMouseOver should be a function');
 
         if(mouseWasOver && !this.mouseIsOver && this.onMouseOut !== undefined)
           if(typeof(this.onMouseOut) === 'function')
             this.onMouseOut.call(this, this);
           else
-            println('Warning: onMouseOut should be a function');
+            print('Warning: onMouseOut should be a function');
 
         if(!mouseWasPressed && this.mouseIsPressed && this.onMousePressed !== undefined)
           if(typeof(this.onMousePressed) === 'function')
             this.onMousePressed.call(this, this);
           else
-            println('Warning: onMousePressed should be a function');
+            print('Warning: onMousePressed should be a function');
 
         if(mouseWasPressed && !pInst.mouseIsPressed && !this.mouseIsPressed && this.onMouseReleased !== undefined)
           if(typeof(this.onMouseReleased) === 'function')
             this.onMouseReleased.call(this, this);
           else
-            println('Warning: onMouseReleased should be a function');
+            print('Warning: onMouseReleased should be a function');
 
       }
 
@@ -1483,7 +1489,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       this.collider = new AABB(pInst, this.position, createVector(width, height), v);
     } else if(type === 'circle') {
       if(arguments.length !== 4) {
-        println('Warning: usage setCollider("circle", offsetX, offsetY, radius)');
+        print('Warning: usage setCollider("circle", offsetX, offsetY, radius)');
       }
 
       this.collider = new CircleCollider(pInst, this.position, width, v);
@@ -1727,7 +1733,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     if(group instanceof Array)
       group.add(this);
     else
-      println('addToGroup error: '+group+' is not a group');
+      print('addToGroup error: '+group+' is not a group');
   };
 
   /**
@@ -1872,12 +1878,12 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
     if(typeof label !== 'string')
     {
-      println('Sprite.addAnimation error: the first argument must be a label (String)');
+      print('Sprite.addAnimation error: the first argument must be a label (String)');
       return -1;
     }
     else if(arguments.length < 2)
     {
-      println('addAnimation error: you must specify a label and n frame images');
+      print('addAnimation error: you must specify a label and n frame images');
       return -1;
     }
     else if(arguments[1] instanceof Animation)
@@ -1956,7 +1962,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   */
   this.changeAnimation = function(label) {
     if(!animations[label])
-      println('changeAnimation error: no animation labeled '+label);
+      print('changeAnimation error: no animation labeled '+label);
     else
     {
       currentAnimation = label;
@@ -1994,7 +2000,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     }
     else
     {
-      println('Error: overlapPixel doesn\'t work with scaled or rotated sprites yet');
+      print('Error: overlapPixel doesn\'t work with scaled or rotated sprites yet');
       //offscreen printing to be implemented bleurch
       return false;
     }
@@ -3523,7 +3529,7 @@ function Animation(pInst) {
   {
     //print("Animation arbitrary mode");
     for (i = 0; i < frameArguments.length; i++) {
-      //println("loading "+fileNames[i]);
+      //print("loading "+fileNames[i]);
       if(frameArguments[i] instanceof p5.Image)
         this.images.push(frameArguments[i]);
       else
@@ -3601,7 +3607,7 @@ function Animation(pInst) {
       }
       else
       {
-        pInst.println('Warning undefined frame '+frame);
+        pInst.print('Warning undefined frame '+frame);
         //this.isActive = false;
       }
 


### PR DESCRIPTION
print() has been removed in p5.js 0.5.3 to avoid other browser naming conflicts so I have replaced it with println() (http://p5js.org/reference/#p5/println). 

https://github.com/processing/p5.js/issues/1573
