### PR TITLE
Clean up goToFrame()

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3736,16 +3736,16 @@ function Animation(pInst) {
   * Plays the animation forward or backward toward a target frame.
   *
   * @method goToFrame
-  * @param {Number} targetFrame Frame number destination (starts from 0)
+  * @param {Number} toFrame Frame number destination (starts from 0)
   */
-  this.goToFrame = function(f) {
-    this.f = f;
+  this.goToFrame = function(toFrame) {
+    if(toFrame >= 0 && toFrame < this.images.length) {
+      targetFrame = toFrame;
+    }
 
-    if(this.f>=0 && this.f<this.images.length)
-      targetFrame = this.f;
-
-    if(targetFrame !== frame)
+    if(targetFrame !== frame) {
       this.playing = true;
+    }
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3739,9 +3739,13 @@ function Animation(pInst) {
   * @param {Number} toFrame Frame number destination (starts from 0)
   */
   this.goToFrame = function(toFrame) {
-    if(toFrame >= 0 && toFrame < this.images.length) {
-      targetFrame = toFrame;
+    if(toFrame < 0 || toFrame >= this.images.length) {
+      return;
     }
+
+    // targetFrame gets used by the update() method to decide what frame to
+    // select next.  When it's not being used it gets set to -1.
+    targetFrame = toFrame;
 
     if(targetFrame !== frame) {
       this.playing = true;

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -2,8 +2,7 @@ describe('Animation', function() {
   var pInst;
 
   beforeEach(function() {
-    pInst = new p5(function() {
-    });
+    pInst = new p5(function() {});
   });
 
   afterEach(function() {
@@ -40,4 +39,148 @@ describe('Animation', function() {
       {name: 7, frame: {x: 30, y: 12, width: 10, height: 12}},
     ]);
   });
+
+  describe('goToFrame()', function() {
+    var animation;
+
+    beforeEach(function() {
+      animation = createTestAnimation(10); // with 10 frames
+      animation.frameDelay = 1; // One update() call = one frame
+    });
+
+    it('plays a paused animation when target != current', function() {
+      var start = 2;
+      for (var target = 0; target < 5; target++) {
+        if (target !== start) {
+          animation.changeFrame(start);
+          animation.stop();
+          expect(animation.playing).to.be.false;
+
+          animation.goToFrame(target);
+          expect(animation.playing).to.be.true;
+        }
+      }
+    });
+
+    it('does not play a paused animation when target == current', function() {
+      for (var startAndTarget = 0; startAndTarget < 5; startAndTarget++) {
+        animation.changeFrame(startAndTarget);
+        animation.stop();
+        expect(animation.playing).to.be.false;
+
+        animation.goToFrame(startAndTarget);
+        expect(animation.playing).to.be.false;
+      }
+    });
+
+    it('never pauses a playing animation immediately', function() {
+      var start = 2;
+      for (var target = 0; target < 5; target++) {
+        animation.changeFrame(start);
+        animation.play();
+        expect(animation.playing).to.be.true;
+
+        animation.goToFrame(target);
+        expect(animation.playing).to.be.true;
+      }
+    });
+
+    it('plays the animation forward to the target frame when target > current', function() {
+      animation.changeFrame(1);
+      animation.goToFrame(4);
+
+      // Verify state on each frame
+      expect(animation.getFrame()).to.equal(1);
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(2);
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(3);
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(4);
+
+      // Note the animation stops at the target frame.
+      animation.update();
+      expect(animation.getFrame()).to.equal(4);
+    });
+
+    it('plays the animation backward to the target frame when target < current', function() {
+      animation.changeFrame(5);
+      animation.goToFrame(2);
+
+      // Verify state on each frame
+      expect(animation.getFrame()).to.equal(5);
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(4);
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(3);
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(2);
+
+      // Note the animation stops at the target frame.
+      animation.update();
+      expect(animation.getFrame()).to.equal(2);
+    });
+
+    it('pauses the frame after it reaches the target frame', function() {
+      // When going forward
+      animation.changeFrame(5);
+      animation.goToFrame(7);
+      expect(animation.playing).to.be.true;
+
+      animation.update();
+      animation.update();
+      expect(animation.getFrame()).to.equal(7);
+      expect(animation.playing).to.be.true;
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(7);
+      expect(animation.playing).to.be.false;
+
+      // When going backward
+      animation.changeFrame(4);
+      animation.goToFrame(2);
+      expect(animation.playing).to.be.true;
+
+      animation.update();
+      animation.update();
+      expect(animation.getFrame()).to.equal(2);
+      expect(animation.playing).to.be.true;
+
+      animation.update();
+      expect(animation.getFrame()).to.equal(2);
+      expect(animation.playing).to.be.false;
+    });
+
+    it('pauses on the next frame when target == current', function() {
+      animation.changeFrame(5);
+      animation.goToFrame(5);
+      expect(animation.playing).to.be.true;
+
+      animation.update();
+      expect(animation.playing).to.be.false;
+    });
+  });
+
+  /**
+   * Makes a fake animation with the specified number of frames.
+   * @param {number} frameCount
+   * @returns {p5.Animation}
+   */
+  function createTestAnimation(frameCount) {
+    frameCount = frameCount || 1;
+    var image = new p5.Image(100, 100, pInst);
+    var frames = [];
+    for (var i = 0; i < frameCount; i++) {
+      frames.push({name: i, frame: {x: 0, y: 0, width: 50, height: 50}});
+    }
+    var sheet = new pInst.SpriteSheet(image, frames);
+    return new pInst.Animation(sheet);
+  }
 });
+

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -165,6 +165,47 @@ describe('Animation', function() {
       animation.update();
       expect(animation.playing).to.be.false;
     });
+
+    describe('when target frame is out of bounds', function() {
+      it('does not affect play behavior', function() {
+        // Play forwards
+        animation.changeFrame(5);
+        animation.play();
+        expect(animation.getFrame()).to.equal(5);
+
+        // Verify playing forwards
+        animation.update();
+        expect(animation.getFrame()).to.equal(6);
+
+        // Try to go to a negative frame.
+        // Unless ignored, we'd expect the animation to start going backwards
+        animation.goToFrame(-1);
+        animation.update();
+        expect(animation.getFrame()).to.equal(7);
+
+        // Play backwards (correctly this time)
+        animation.goToFrame(0);
+        animation.update();
+        expect(animation.getFrame()).to.equal(6);
+
+        // Try going to a positive frame out of bounds
+        // Unless ignored, we'd expect the animation to run forward again
+        animation.goToFrame(animation.images.length);
+        animation.update();
+        expect(animation.getFrame()).to.equal(5);
+      });
+
+      it('does not affect play state', function() {
+        animation.stop();
+        expect(animation.playing).to.be.false;
+
+        animation.goToFrame(-1);
+        expect(animation.playing).to.be.false;
+
+        animation.goToFrame(animation.images.length);
+        expect(animation.playing).to.be.false;
+      });
+    });
   });
 
   /**


### PR DESCRIPTION
I noticed an instance variable `this.f` only used within `Animation.goToFrame()` that could be removed, which led me to test and clean up that method.  This PR does the following:
- Adds a new test file for `Animation` and a small set of tests covering the expected behavior of `goToFrame()`
- Removes the unused `this.f` variable, gives the parameter a more descriptive name and updates the documentation to match, and uses curly braces for blocks.
- Makes exactly one change to the behavior of `goToFrame()`:
  
  There was an edge case in the existing implementation, where calling `goToFrame()` with an invalid frame index on a paused animation would unpause that animation, even though it didn't actually set the target frame.  This seemed against the original intent of the bounds-check, which I think was supposed to do nothing when given an invalid frame index.  I've updated it to actually do nothing in this case.
# New tests

```
  Animation
    goToFrame()
      ✓ plays a paused animation when target != current 
      ✓ does not play a paused animation when target == current 
      ✓ never pauses a playing animation immediately 
      ✓ plays the animation forward to the target frame when target > current 
      ✓ plays the animation backward to the target frame when target < current 
      ✓ pauses the frame after it reaches the target frame 
      ✓ pauses on the next frame when target == current 
      when target frame is out of bounds
        ✓ does not affect play behavior 
        ✓ does not affect play state 
```
