### PR TITLE
Support setCollider("circle")

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1465,27 +1465,37 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * a collision detection so you can set a circular or rectangular sprite with different
   * dimensions and offset from the sprite's center.
   *
-  * setCollider
+  * There are three ways to call this method:
+  *
+  * 1. setCollider("rectangle", offsetX, offsetY, width, height)
+  * 2. setCollider("circle", offsetX, offsetY, radius)
+  * 3. setCollider("circle") - will use no offset and guess radius
+  *
   * @method setCollider
   * @param {String} type Either "rectangle" or "circle"
   * @param {Number} offsetX Collider x position from the center of the sprite
   * @param {Number} offsetY Collider y position from the center of the sprite
   * @param {Number} width Collider width or radius
   * @param {Number} height Collider height
-  *
+  * @throws {TypeError} if given invalid parameters.
   */
   this.setCollider = function(type, offsetX, offsetY, width, height) {
+    if (!(type === 'rectangle' || type === 'circle')) {
+      throw new TypeError('setCollider expects the first argument to be either "circle" or "rectangle"');
+    } else if (type === 'circle' && !(arguments.length === 1 || arguments.length === 4)) {
+      throw new TypeError('Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+    } else if (type === 'rectangle' && !(arguments.length === 5)) {
+      throw new TypeError('Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+    }
 
     this.colliderType = 'custom';
 
     var v = createVector(offsetX, offsetY);
-    if(type === 'rectangle' && arguments.length === 5) {
+    if (type === 'rectangle' && arguments.length === 5) {
       this.collider = new AABB(pInst, this.position, createVector(width, height), v);
-    } else if(type === 'circle') {
-      if(arguments.length !== 4) {
-        print('Warning: usage setCollider("circle", offsetX, offsetY, radius)');
-      }
-
+    } else if (type === 'circle' && arguments.length === 1) {
+      this.collider = new CircleCollider(pInst, this.position, Math.floor(Math.max(this.width, this.height) / 2));
+    } else if (type === 'circle' && arguments.length === 4) {
       this.collider = new CircleCollider(pInst, this.position, width, v);
     }
 

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -290,4 +290,93 @@ describe('Sprite', function() {
       });
     });
   });
+
+  describe('setCollider()', function() {
+    var sprite;
+
+    beforeEach(function() {
+      // Position: (10, 20), Size: (30, 40)
+      sprite = pInst.createSprite(10, 20, 30, 40);
+    });
+
+    it('a newly-created sprite has no collider', function() {
+      expect(sprite.collider).to.be.undefined;
+    });
+
+    it('throws if first argument is not "circle" or "rectangle"', function() {
+      // Also throws if undefined
+      expect(function() {
+        sprite.setCollider();
+      }).to.throw(TypeError, 'setCollider expects the first argument to be either "circle" or "rectangle"');
+
+      // Note, it's case-sensitive
+      expect(function() {
+        sprite.setCollider('CIRCLE');
+      }).to.throw(TypeError, 'setCollider expects the first argument to be either "circle" or "rectangle"');
+    });
+
+    it('can construct a circle collider with default radius and offset', function() {
+      sprite.setCollider('circle');
+      expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
+      expect(sprite.collider.center).to.eq(sprite.position);
+      expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.offset.x).to.eq(0);
+      expect(sprite.collider.offset.y).to.eq(0);
+      // Radius should be half of sprite's larger dimension.
+      expect(sprite.collider.radius).to.eq(20);
+    });
+
+    it('can construct a circle collider with explicit radius and offset', function() {
+      sprite.setCollider('circle', 1, 2, 3);
+      expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
+      expect(sprite.collider.center).to.eq(sprite.position);
+      expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.offset.x).to.eq(1);
+      expect(sprite.collider.offset.y).to.eq(2);
+      expect(sprite.collider.radius).to.eq(3);
+    });
+
+    it('throws if creating a circle collider with 1, 2, or 4+ params', function() {
+      expect(function() {
+        sprite.setCollider('circle', 1);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+      expect(function() {
+        sprite.setCollider('circle', 1, 2);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+      // setCollider('circle', 1, 2, 3) is fine
+      expect(function() {
+        sprite.setCollider('circle', 1, 2, 3, 4);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+      expect(function() {
+        sprite.setCollider('circle', 1, 2, 3, 4, 5);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+    });
+
+    it('can construct a rectangle collider with explicit dimensions and offset', function() {
+      sprite.setCollider('rectangle', 1, 2, 3, 4);
+      expect(sprite.collider).to.be.an.instanceOf(pInst.AABB);
+    });
+
+    it('throws if creating a rectangle collider with 0, 1, 2, 3, or 5+ params', function() {
+      expect(function() {
+        sprite.setCollider('rectangle');
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2, 3);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      // setCollider('rectangle', 1, 2, 3, 4) is fine.
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2, 3, 4, 5);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2, 3, 4, 5, 6);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+    });
+  });
 });


### PR DESCRIPTION
Two changes:
1. `setCollider("circle")` with no additional parameters is now allowed, and will attempt to select sensible defaults for the collider's offset (`[0,0]`) and radius (`floor(max(sprite.width, sprite.height) / 2)`).
   
   This is a feature we're implementing for Code.org's Gamelab, but it seems like it might be useful upstream as a change that simplifies the API without making any breaking changes.
2. `setCollider` will now throw a [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) when given any combination of arguments that it can't handle correctly.
   
   Before, this method could be called with invalid arguments and put the sprite in a bad state - with `colliderType` set to `'custom'` and the sprite in the quadTree, but `collider` still `undefined` - or possibly with a `CircleCollider` that has an undefined `radius`.  It would _sometimes_ print a warning, and sometimes fail silently.
   
   Now only these three parameter sets are allowed:
   - `setCollider('rectangle', offsetX, offsetY, width, height)`
   - `setCollider('circle', offsetX, offsetY, radius)`
   - `setCollider('circle')`
   
   All other call patterns will result in a `TypeError` with a useful message, and no other side effects.
# New Tests

```
  Sprite
    setCollider()
      ✓ a newly-created sprite has no collider 
      ✓ throws if first argument is not "circle" or "rectangle" 
      ✓ can construct a circle collider with default radius and offset 
      ✓ can construct a circle collider with explicit radius and offset 
      ✓ throws if creating a circle collider with 1, 2, or 4+ params 
      ✓ can construct a rectangle collider with explicit dimensions and offset 
      ✓ throws if creating a rectangle collider with 0, 1, 2, 3, or 5+ params 

```
