### PR TITLE
Fix CircleCollider offsets

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2991,19 +2991,21 @@ function CircleCollider(pInst, _center, _radius, _offset) {
   //should be called only for circle vs circle
   this.collide = function(other)
   {
-
-    if(this.overlap(other))
-    {
-      var a = pInst.atan2(this.center.y-other.center.y, this.center.x-other.center.x);
+    if(this.overlap(other)) {
+      var thisCenterX = this.center.x + this.offset.x;
+      var thisCenterY = this.center.y + this.offset.y;
+      var otherCenterX = other.center.x + other.offset.x;
+      var otherCenterY = other.center.y + other.offset.y;
+      var a = pInst.atan2(thisCenterY-otherCenterY, thisCenterX-otherCenterX);
       var radii = this.radius+other.radius;
-      var intersection = abs(radii - dist(this.center.x, this.center.y, other.center.x, other.center.y));
+      var intersection = abs(radii - dist(thisCenterX, thisCenterY, otherCenterX, otherCenterY));
 
       var displacement = createVector(pInst.cos(a)*intersection, pInst.sin(a)*intersection);
 
       return displacement;
-    }
-    else
+    } else {
       return createVector(0, 0);
+    }
   };
 
   this.size = function()

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2980,7 +2980,11 @@ function CircleCollider(pInst, _center, _radius, _offset) {
     //square dist
     var r = this.radius + other.radius;
     r *= r;
-    var sqDist = pow(this.center.x - other.center.x, 2) + pow(this.center.y - other.center.y, 2);
+    var thisCenterX = this.center.x + this.offset.x;
+    var thisCenterY = this.center.y + this.offset.y;
+    var otherCenterX = other.center.x + other.offset.x;
+    var otherCenterY = other.center.y + other.offset.y;
+    var sqDist = pow(thisCenterX - otherCenterX, 2) + pow(thisCenterY - otherCenterY, 2);
     return r > sqDist;
   };
 

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
     <script src="../examples/lib/p5.js"></script>
     <script src="../lib/p5.play.js"></script>
     <script src="unit/animation.js"></script>
+    <script src="unit/circle-collider.js"></script>
     <script src="unit/collisions.js"></script>
     <script src="unit/group.js"></script>
     <script src="unit/input.js"></script>

--- a/test/unit/circle-collider.js
+++ b/test/unit/circle-collider.js
@@ -1,0 +1,196 @@
+describe('CircleCollider', function() {
+  var pInst;
+
+  beforeEach(function() {
+    pInst = new p5(function() {});
+  });
+
+  afterEach(function() {
+    pInst.remove();
+  });
+
+  // Create with zero offset and radius=1 to simplify tests
+  function makeAt(x, y) {
+    return new pInst.CircleCollider(
+      new p5.Vector(x, y),
+      1,
+      new p5.Vector(0, 0)
+    );
+  }
+
+  it('conforms to the collider interface', function() {
+    // Still figuring out what this is though;
+    var collider = new pInst.CircleCollider();
+    expect(collider).to.haveOwnProperty('draw');
+    expect(collider).to.haveOwnProperty('overlap');
+    expect(collider).to.haveOwnProperty('collide');
+    expect(collider).to.haveOwnProperty('size');
+    expect(collider).to.haveOwnProperty('left');
+    expect(collider).to.haveOwnProperty('right');
+    expect(collider).to.haveOwnProperty('top');
+    expect(collider).to.haveOwnProperty('bottom');
+  });
+
+  describe('overlap()', function() {
+    describe('circle-circle', function() {
+      // Returns a boolean.
+      it('true when exactly overlapped', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(2, 2);
+        expect(a.overlap(b)).to.be.true;
+        expect(b.overlap(a)).to.be.true;
+      });
+
+      it('true when partially overlapped', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(2, 3);
+        expect(a.overlap(b)).to.be.true;
+        expect(b.overlap(a)).to.be.true;
+      });
+
+      it('false when tangent along axes', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(4, 2); // Separated by 2 on the x-axis
+        expect(a.overlap(b)).to.be.false;
+        expect(b.overlap(a)).to.be.false;
+
+        var c = makeAt(2, 4); // Separated by 2 on the y-axis
+        expect(a.overlap(c)).to.be.false;
+        expect(c.overlap(a)).to.be.false;
+      });
+
+      it('true when tangent along 45deg line', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(2 + 2*Math.cos(Math.PI / 4),
+                       2 + 2*Math.sin(Math.PI / 4));
+        expect(a.overlap(b)).to.be.true;
+        expect(b.overlap(a)).to.be.true;
+      });
+
+      it('false when distant along axes', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(5, 2); // Separated by 3 on the x-axis
+        expect(a.overlap(b)).to.be.false;
+        expect(b.overlap(a)).to.be.false;
+
+        var c = makeAt(2, 5); // Separated by 3 on the y-axis
+        expect(a.overlap(c)).to.be.false;
+        expect(c.overlap(a)).to.be.false;
+      });
+
+      it('false when distant along 45deg line', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(4, 4); // Separated by 2 on both x and y axes
+        expect(a.overlap(b)).to.be.false;
+        expect(b.overlap(a)).to.be.false;
+      });
+    });
+  });
+
+  describe('collide()', function() {
+    // Returns an displacement vector
+    describe('circle-circle', function() {
+      it('projects horizontally when exactly overlapped', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(2, 2);
+        var displacementA = a.collide(b);
+        var displacementB = b.collide(a);
+        expect(displacementA.x).to.equal(2);
+        expect(displacementA.y).to.equal(0);
+        expect(displacementB.x).to.equal(2);
+        expect(displacementB.y).to.equal(0);
+      });
+
+      it('projects out when partially overlapped along axes', function() {
+        var a = makeAt(2, 2);
+        var b = makeAt(2, 3);
+        var verticalDisplacementA = a.collide(b);
+        var verticalDisplacementB = b.collide(a);
+        expect(verticalDisplacementA.x).to.closeTo(0, 0.001);
+        expect(verticalDisplacementA.y).to.equal(-1);
+        expect(verticalDisplacementB.x).to.closeTo(0, 0.001);
+        expect(verticalDisplacementB.y).to.equal(1);
+
+        var c = makeAt(3, 2);
+        var horizontalDisplacementA = a.collide(c);
+        var horizontalDisplacementB = c.collide(a);
+        expect(horizontalDisplacementA.x).to.equal(-1);
+        expect(horizontalDisplacementA.y).to.closeTo(0, 0.001);
+        expect(horizontalDisplacementB.x).to.equal(1);
+        expect(horizontalDisplacementB.y).to.closeTo(0, 0.001);
+      });
+
+      it('projects at an angle when overlapped at an angle', function () {
+        var a = makeAt(2, 2);
+
+        // At 45deg
+        var b = makeAt(3, 3);
+        var displacementA = a.collide(b);
+        var displacementB = b.collide(a);
+        expect(displacementA.x).to.be.closeTo(-0.414, 0.001);
+        expect(displacementA.y).to.be.closeTo(-0.414, 0.001);
+        expect(displacementB.x).to.be.closeTo(0.414, 0.001);
+        expect(displacementB.y).to.be.closeTo(0.414, 0.001);
+
+        var c = makeAt(1.5, 3);
+        var displacementC = a.collide(c);
+        var displacementD = c.collide(a);
+        expect(displacementC.x).to.be.closeTo(0.394, 0.001);
+        expect(displacementC.y).to.be.closeTo(-0.788, 0.001);
+        expect(displacementD.x).to.be.closeTo(-0.394, 0.001);
+        expect(displacementD.y).to.be.closeTo(0.788, 0.001);
+      });
+
+      it('returns zero vector when not overlapping', function() {
+        var a = makeAt(2, 2);
+
+        var b = makeAt(5, 2); // Separated by 3 on the x-axis
+        var displacementB1 = a.collide(b);
+        var displacementB2 = b.collide(a);
+        expect(displacementB1.x).to.equal(0);
+        expect(displacementB1.y).to.equal(0);
+        expect(displacementB2.x).to.equal(0);
+        expect(displacementB2.y).to.equal(0);
+
+        var c = makeAt(2, 5); // Separated by 3 on the y-axis
+        var displacementC1 = a.collide(c);
+        var displacementC2 = c.collide(a);
+        expect(displacementC1.x).to.equal(0);
+        expect(displacementC1.y).to.equal(0);
+        expect(displacementC2.x).to.equal(0);
+        expect(displacementC2.y).to.equal(0);
+
+        var d = makeAt(4, 4); // Separated by 2 on both x and y axes
+        var displacementD1 = a.collide(d);
+        var displacementD2 = d.collide(a);
+        expect(displacementD1.x).to.equal(0);
+        expect(displacementD1.y).to.equal(0);
+        expect(displacementD2.x).to.equal(0);
+        expect(displacementD2.y).to.equal(0);
+      });
+    });
+  });
+
+  describe('size()', function() {
+    var collider, radius;
+
+    beforeEach(function (){
+      radius = Math.floor(100 * Math.random());
+      collider = new pInst.CircleCollider(
+        new p5.Vector(0, 0),
+        radius,
+        new p5.Vector(0, 0)
+      );
+    });
+
+    it('returns a p5.Vector', function() {
+       expect(collider.size()).to.be.an.instanceOf(p5.Vector);
+    });
+
+    it('is twice the circle radius in each direction', function () {
+      var size = collider.size();
+      expect(size.x).to.equal(2*radius);
+      expect(size.y).to.equal(2*radius);
+    })
+  });
+});

--- a/test/unit/circle-collider.js
+++ b/test/unit/circle-collider.js
@@ -228,6 +228,85 @@ describe('CircleCollider', function() {
         expect(displacementD2.x).to.equal(0);
         expect(displacementD2.y).to.equal(0);
       });
+
+      it('projects horizontally when exactly overlapped by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(2, 2);
+        var displacementB1 = a.collide(b);
+        var displacementB2 = b.collide(a);
+        expect(displacementB1.x).to.equal(2);
+        expect(displacementB1.y).to.equal(0);
+        expect(displacementB2.x).to.equal(2);
+        expect(displacementB2.y).to.equal(0);
+      });
+
+      it('projects out when partially overlapped along axes by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(2, 3);
+        var verticalDisplacement1 = a.collide(b);
+        var verticalDisplacement2 = b.collide(a);
+        expect(verticalDisplacement1.x).to.closeTo(0, 0.001);
+        expect(verticalDisplacement1.y).to.equal(-1);
+        expect(verticalDisplacement2.x).to.closeTo(0, 0.001);
+        expect(verticalDisplacement2.y).to.equal(1);
+
+        var c = makeWithOffset(3, 2);
+        var horizontalDisplacement1 = a.collide(c);
+        var horizontalDisplacement2 = c.collide(a);
+        expect(horizontalDisplacement1.x).to.equal(-1);
+        expect(horizontalDisplacement1.y).to.closeTo(0, 0.001);
+        expect(horizontalDisplacement2.x).to.equal(1);
+        expect(horizontalDisplacement2.y).to.closeTo(0, 0.001);
+      });
+
+      it('projects at an angle when overlapped at an angle by offset', function() {
+        var a = makeAt(2, 2);
+
+        // At 45deg
+        var b = makeWithOffset(3, 3);
+        var displacementB1 = a.collide(b);
+        var displacementB2 = b.collide(a);
+        expect(displacementB1.x).to.be.closeTo(-0.414, 0.001);
+        expect(displacementB1.y).to.be.closeTo(-0.414, 0.001);
+        expect(displacementB2.x).to.be.closeTo(0.414, 0.001);
+        expect(displacementB2.y).to.be.closeTo(0.414, 0.001);
+
+        var c = makeWithOffset(1.5, 3);
+        var displacementC1 = a.collide(c);
+        var displacementC2 = c.collide(a);
+        expect(displacementC1.x).to.be.closeTo(0.394, 0.001);
+        expect(displacementC1.y).to.be.closeTo(-0.788, 0.001);
+        expect(displacementC2.x).to.be.closeTo(-0.394, 0.001);
+        expect(displacementC2.y).to.be.closeTo(0.788, 0.001);
+      });
+
+      it('returns zero vector when not overlapping by offset', function() {
+        var a = makeAt(2, 2);
+
+        var b = makeWithOffset(5, 2); // Separated by 3 on the x-axis
+        var displacementB1 = a.collide(b);
+        var displacementB2 = b.collide(a);
+        expect(displacementB1.x).to.equal(0);
+        expect(displacementB1.y).to.equal(0);
+        expect(displacementB2.x).to.equal(0);
+        expect(displacementB2.y).to.equal(0);
+
+        var c = makeWithOffset(2, 5); // Separated by 3 on the y-axis
+        var displacementC1 = a.collide(c);
+        var displacementC2 = c.collide(a);
+        expect(displacementC1.x).to.equal(0);
+        expect(displacementC1.y).to.equal(0);
+        expect(displacementC2.x).to.equal(0);
+        expect(displacementC2.y).to.equal(0);
+
+        var d = makeWithOffset(4, 4); // Separated by 2 on both x and y axes
+        var displacementD1 = a.collide(d);
+        var displacementD2 = d.collide(a);
+        expect(displacementD1.x).to.equal(0);
+        expect(displacementD1.y).to.equal(0);
+        expect(displacementD2.x).to.equal(0);
+        expect(displacementD2.y).to.equal(0);
+      });
     });
   });
 

--- a/test/unit/circle-collider.js
+++ b/test/unit/circle-collider.js
@@ -18,6 +18,15 @@ describe('CircleCollider', function() {
     );
   }
 
+  // Create at a (0,0) with radius=1 to test use of offsets
+  function makeWithOffset(x, y) {
+    return new pInst.CircleCollider(
+      new p5.Vector(0, 0),
+      1,
+      new p5.Vector(x, y)
+    );
+  }
+
   it('conforms to the collider interface', function() {
     // Still figuring out what this is though;
     var collider = new pInst.CircleCollider();
@@ -61,8 +70,8 @@ describe('CircleCollider', function() {
 
       it('true when tangent along 45deg line', function() {
         var a = makeAt(2, 2);
-        var b = makeAt(2 + 2*Math.cos(Math.PI / 4),
-                       2 + 2*Math.sin(Math.PI / 4));
+        var b = makeAt(2 + 2 * Math.cos(Math.PI / 4),
+                       2 + 2 * Math.sin(Math.PI / 4));
         expect(a.overlap(b)).to.be.true;
         expect(b.overlap(a)).to.be.true;
       });
@@ -81,6 +90,57 @@ describe('CircleCollider', function() {
       it('false when distant along 45deg line', function() {
         var a = makeAt(2, 2);
         var b = makeAt(4, 4); // Separated by 2 on both x and y axes
+        expect(a.overlap(b)).to.be.false;
+        expect(b.overlap(a)).to.be.false;
+      });
+
+      it('true when exactly overlapped by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(2, 2);
+        expect(a.overlap(b)).to.be.true;
+        expect(b.overlap(a)).to.be.true;
+      });
+
+      it('true when partially overlapped by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(2, 3);
+        expect(a.overlap(b)).to.be.true;
+        expect(b.overlap(a)).to.be.true;
+      });
+
+      it('false when tangent along axes by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(4, 2); // Separated by 2 on the x-axis
+        expect(a.overlap(b)).to.be.false;
+        expect(b.overlap(a)).to.be.false;
+
+        var c = makeWithOffset(2, 4); // Separated by 2 on the y-axis
+        expect(a.overlap(c)).to.be.false;
+        expect(c.overlap(a)).to.be.false;
+      });
+
+      it('true when tangent along 45deg line by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(2 + 2 * Math.cos(Math.PI / 4),
+          2 + 2 * Math.sin(Math.PI / 4));
+        expect(a.overlap(b)).to.be.true;
+        expect(b.overlap(a)).to.be.true;
+      });
+
+      it('false when distant along axes by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(5, 2); // Separated by 3 on the x-axis
+        expect(a.overlap(b)).to.be.false;
+        expect(b.overlap(a)).to.be.false;
+
+        var c = makeWithOffset(2, 5); // Separated by 3 on the y-axis
+        expect(a.overlap(c)).to.be.false;
+        expect(c.overlap(a)).to.be.false;
+      });
+
+      it('false when distant along 45deg line by offset', function() {
+        var a = makeAt(2, 2);
+        var b = makeWithOffset(4, 4); // Separated by 2 on both x and y axes
         expect(a.overlap(b)).to.be.false;
         expect(b.overlap(a)).to.be.false;
       });
@@ -120,7 +180,7 @@ describe('CircleCollider', function() {
         expect(horizontalDisplacementB.y).to.closeTo(0, 0.001);
       });
 
-      it('projects at an angle when overlapped at an angle', function () {
+      it('projects at an angle when overlapped at an angle', function() {
         var a = makeAt(2, 2);
 
         // At 45deg
@@ -174,7 +234,7 @@ describe('CircleCollider', function() {
   describe('size()', function() {
     var collider, radius;
 
-    beforeEach(function (){
+    beforeEach(function() {
       radius = Math.floor(100 * Math.random());
       collider = new pInst.CircleCollider(
         new p5.Vector(0, 0),
@@ -184,13 +244,13 @@ describe('CircleCollider', function() {
     });
 
     it('returns a p5.Vector', function() {
-       expect(collider.size()).to.be.an.instanceOf(p5.Vector);
+      expect(collider.size()).to.be.an.instanceOf(p5.Vector);
     });
 
-    it('is twice the circle radius in each direction', function () {
+    it('is twice the circle radius in each direction', function() {
       var size = collider.size();
-      expect(size.x).to.equal(2*radius);
-      expect(size.y).to.equal(2*radius);
-    })
+      expect(size.x).to.equal(2 * radius);
+      expect(size.y).to.equal(2 * radius);
+    });
   });
 });

--- a/test/unit/circle-collider.js
+++ b/test/unit/circle-collider.js
@@ -153,31 +153,32 @@ describe('CircleCollider', function() {
       it('projects horizontally when exactly overlapped', function() {
         var a = makeAt(2, 2);
         var b = makeAt(2, 2);
-        var displacementA = a.collide(b);
-        var displacementB = b.collide(a);
-        expect(displacementA.x).to.equal(2);
-        expect(displacementA.y).to.equal(0);
-        expect(displacementB.x).to.equal(2);
-        expect(displacementB.y).to.equal(0);
+        var displacement1 = a.collide(b);
+        var displacement2 = b.collide(a);
+        expect(displacement1.x).to.equal(2);
+        expect(displacement1.y).to.equal(0);
+        expect(displacement2.x).to.equal(2);
+        expect(displacement2.y).to.equal(0);
       });
 
       it('projects out when partially overlapped along axes', function() {
         var a = makeAt(2, 2);
+
         var b = makeAt(2, 3);
-        var verticalDisplacementA = a.collide(b);
-        var verticalDisplacementB = b.collide(a);
-        expect(verticalDisplacementA.x).to.closeTo(0, 0.001);
-        expect(verticalDisplacementA.y).to.equal(-1);
-        expect(verticalDisplacementB.x).to.closeTo(0, 0.001);
-        expect(verticalDisplacementB.y).to.equal(1);
+        var verticalDisplacement1 = a.collide(b);
+        var verticalDisplacement2 = b.collide(a);
+        expect(verticalDisplacement1.x).to.closeTo(0, 0.001);
+        expect(verticalDisplacement1.y).to.equal(-1);
+        expect(verticalDisplacement2.x).to.closeTo(0, 0.001);
+        expect(verticalDisplacement2.y).to.equal(1);
 
         var c = makeAt(3, 2);
-        var horizontalDisplacementA = a.collide(c);
-        var horizontalDisplacementB = c.collide(a);
-        expect(horizontalDisplacementA.x).to.equal(-1);
-        expect(horizontalDisplacementA.y).to.closeTo(0, 0.001);
-        expect(horizontalDisplacementB.x).to.equal(1);
-        expect(horizontalDisplacementB.y).to.closeTo(0, 0.001);
+        var horizontalDisplacement1 = a.collide(c);
+        var horizontalDisplacement2 = c.collide(a);
+        expect(horizontalDisplacement1.x).to.equal(-1);
+        expect(horizontalDisplacement1.y).to.closeTo(0, 0.001);
+        expect(horizontalDisplacement2.x).to.equal(1);
+        expect(horizontalDisplacement2.y).to.closeTo(0, 0.001);
       });
 
       it('projects at an angle when overlapped at an angle', function() {
@@ -185,20 +186,20 @@ describe('CircleCollider', function() {
 
         // At 45deg
         var b = makeAt(3, 3);
-        var displacementA = a.collide(b);
-        var displacementB = b.collide(a);
-        expect(displacementA.x).to.be.closeTo(-0.414, 0.001);
-        expect(displacementA.y).to.be.closeTo(-0.414, 0.001);
-        expect(displacementB.x).to.be.closeTo(0.414, 0.001);
-        expect(displacementB.y).to.be.closeTo(0.414, 0.001);
+        var displacementB1 = a.collide(b);
+        var displacementB2 = b.collide(a);
+        expect(displacementB1.x).to.be.closeTo(-0.414, 0.001);
+        expect(displacementB1.y).to.be.closeTo(-0.414, 0.001);
+        expect(displacementB2.x).to.be.closeTo(0.414, 0.001);
+        expect(displacementB2.y).to.be.closeTo(0.414, 0.001);
 
         var c = makeAt(1.5, 3);
-        var displacementC = a.collide(c);
-        var displacementD = c.collide(a);
-        expect(displacementC.x).to.be.closeTo(0.394, 0.001);
-        expect(displacementC.y).to.be.closeTo(-0.788, 0.001);
-        expect(displacementD.x).to.be.closeTo(-0.394, 0.001);
-        expect(displacementD.y).to.be.closeTo(0.788, 0.001);
+        var displacementC1 = a.collide(c);
+        var displacementC2 = c.collide(a);
+        expect(displacementC1.x).to.be.closeTo(0.394, 0.001);
+        expect(displacementC1.y).to.be.closeTo(-0.788, 0.001);
+        expect(displacementC2.x).to.be.closeTo(-0.394, 0.001);
+        expect(displacementC2.y).to.be.closeTo(0.788, 0.001);
       });
 
       it('returns zero vector when not overlapping', function() {
@@ -232,16 +233,17 @@ describe('CircleCollider', function() {
       it('projects horizontally when exactly overlapped by offset', function() {
         var a = makeAt(2, 2);
         var b = makeWithOffset(2, 2);
-        var displacementB1 = a.collide(b);
-        var displacementB2 = b.collide(a);
-        expect(displacementB1.x).to.equal(2);
-        expect(displacementB1.y).to.equal(0);
-        expect(displacementB2.x).to.equal(2);
-        expect(displacementB2.y).to.equal(0);
+        var displacement1 = a.collide(b);
+        var displacement2 = b.collide(a);
+        expect(displacement1.x).to.equal(2);
+        expect(displacement1.y).to.equal(0);
+        expect(displacement2.x).to.equal(2);
+        expect(displacement2.y).to.equal(0);
       });
 
       it('projects out when partially overlapped along axes by offset', function() {
         var a = makeAt(2, 2);
+
         var b = makeWithOffset(2, 3);
         var verticalDisplacement1 = a.collide(b);
         var verticalDisplacement2 = b.collide(a);


### PR DESCRIPTION
The methods `CircleCollider.overlap()` and `CircleCollider.collide()` were not respecting offsets passed to the collider when it was created, leading to this incorrect behavior (note that the debug drawing for the colliders uses the offset correctly):

![before](https://cloud.githubusercontent.com/assets/1615761/19332632/fe039606-90a2-11e6-9353-2e65286d4e00.gif)

[_View test case source_](https://gist.github.com/islemaster/d38d84b74d533183a8053310b0fe05a1)

I've updated the two methods to respect the offset, fixing the behavior:

![after](https://cloud.githubusercontent.com/assets/1615761/19332736/ca16b32c-90a3-11e6-86ea-da7a0eaff65e.gif)

Please note that this fix is not dependent on the `Sprite.setCollider` API change proposed in https://github.com/molleindustria/p5.play/pull/112 and can be accepted independent of it.
# New Tests

I noticed this while writing a suite of unit tests for `CircleCollider`, included here and at least covering circle-circle collisions.

```
  CircleCollider
    ✓ conforms to the collider interface 
    overlap()
      circle-circle
        ✓ true when exactly overlapped 
        ✓ true when partially overlapped 
        ✓ false when tangent along axes 
        ✓ true when tangent along 45deg line 
        ✓ false when distant along axes 
        ✓ false when distant along 45deg line 
        ✓ true when exactly overlapped by offset 
        ✓ true when partially overlapped by offset 
        ✓ false when tangent along axes by offset 
        ✓ true when tangent along 45deg line by offset 
        ✓ false when distant along axes by offset 
        ✓ false when distant along 45deg line by offset 
    collide()
      circle-circle
        ✓ projects horizontally when exactly overlapped 
        ✓ projects out when partially overlapped along axes 
        ✓ projects at an angle when overlapped at an angle 
        ✓ returns zero vector when not overlapping 
        ✓ projects horizontally when exactly overlapped by offset 
        ✓ projects out when partially overlapped along axes by offset 
        ✓ projects at an angle when overlapped at an angle by offset 
        ✓ returns zero vector when not overlapping by offset 
    size()
      ✓ returns a p5.Vector 
      ✓ is twice the circle radius in each direction 

```
