### PR TITLE
Correct reference to p5.play in empty.html

### DIFF
--- a/examples/empty.html
+++ b/examples/empty.html
@@ -5,7 +5,7 @@
     <!-- link p5.js and its addons like p5.dom.js or p5.sound.js -->
     <script src="lib/p5.js" type="text/javascript"></script>
     <!-- link p5.play.js -->
-    <script src="lib/p5.play.js" type="text/javascript"></script>  
+    <script src="../lib/p5.play.js" type="text/javascript"></script>
     <!-- link your javascript sketch -->
     <script src="empty.js" type="text/javascript"></script>
   </head>


### PR DESCRIPTION
I'm not sure what this `empty.html` file is used for, but it's a really nice way to get an ad-hoc experiment up and running.  Unfortunately its reference to `p5.play.js` was broken.  This just fixes its relative path.