### PR TITLE
Support setCollider("rectangle")

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1465,27 +1465,37 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * a collision detection so you can set a circular or rectangular sprite with different
   * dimensions and offset from the sprite's center.
   *
-  * setCollider
+  * There are three ways to call this method:
+  *
+  * 1. setCollider("rectangle", offsetX, offsetY, width, height)
+  * 2. setCollider("circle", offsetX, offsetY, radius)
+  * 3. setCollider("circle") - will use no offset and guess radius
+  *
   * @method setCollider
   * @param {String} type Either "rectangle" or "circle"
   * @param {Number} offsetX Collider x position from the center of the sprite
   * @param {Number} offsetY Collider y position from the center of the sprite
   * @param {Number} width Collider width or radius
   * @param {Number} height Collider height
-  *
+  * @throws {TypeError} if given invalid parameters.
   */
   this.setCollider = function(type, offsetX, offsetY, width, height) {
+    if (!(type === 'rectangle' || type === 'circle')) {
+      throw new TypeError('setCollider expects the first argument to be either "circle" or "rectangle"');
+    } else if (type === 'circle' && !(arguments.length === 1 || arguments.length === 4)) {
+      throw new TypeError('Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+    } else if (type === 'rectangle' && !(arguments.length === 5)) {
+      throw new TypeError('Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+    }
 
     this.colliderType = 'custom';
 
     var v = createVector(offsetX, offsetY);
-    if(type === 'rectangle' && arguments.length === 5) {
+    if (type === 'rectangle' && arguments.length === 5) {
       this.collider = new AABB(pInst, this.position, createVector(width, height), v);
-    } else if(type === 'circle') {
-      if(arguments.length !== 4) {
-        print('Warning: usage setCollider("circle", offsetX, offsetY, radius)');
-      }
-
+    } else if (type === 'circle' && arguments.length === 1) {
+      this.collider = new CircleCollider(pInst, this.position, Math.floor(Math.max(this.width, this.height) / 2));
+    } else if (type === 'circle' && arguments.length === 4) {
       this.collider = new CircleCollider(pInst, this.position, width, v);
     }
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1484,14 +1484,16 @@ function Sprite(pInst, _x, _y, _w, _h) {
       throw new TypeError('setCollider expects the first argument to be either "circle" or "rectangle"');
     } else if (type === 'circle' && !(arguments.length === 1 || arguments.length === 4)) {
       throw new TypeError('Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
-    } else if (type === 'rectangle' && !(arguments.length === 5)) {
-      throw new TypeError('Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+    } else if (type === 'rectangle' && !(arguments.length === 1 || arguments.length === 5)) {
+      throw new TypeError('Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
     }
 
     this.colliderType = 'custom';
 
     var v = createVector(offsetX, offsetY);
-    if (type === 'rectangle' && arguments.length === 5) {
+    if (type === 'rectangle' && arguments.length === 1) {
+      this.collider = new AABB(pInst, this.position, createVector(this.width, this.height));
+    } else if (type === 'rectangle' && arguments.length === 5) {
       this.collider = new AABB(pInst, this.position, createVector(width, height), v);
     } else if (type === 'circle' && arguments.length === 1) {
       this.collider = new CircleCollider(pInst, this.position, Math.floor(Math.max(this.width, this.height) / 2));

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1457,19 +1457,21 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * will be used to detect collisions and overlapping with other sprites,
   * or the mouse cursor.
   *
-  * If the sprite is checked for collision, bounce, overlapping or mouse events a
-  * collider is automatically created from the width and height parameter passed at the
-  * creation of the sprite or the from the image dimension in case of animate sprites.
+  * If the sprite is checked for collision, bounce, overlapping or mouse events
+  * a collider is automatically created from the width and height parameter
+  * passed at the creation of the sprite or the from the image dimension in case
+  * of animated sprites.
   *
-  * Often the image bounding box is not appropriate as active area for
-  * a collision detection so you can set a circular or rectangular sprite with different
-  * dimensions and offset from the sprite's center.
+  * Often the image bounding box is not appropriate as the active area for
+  * collision detection so you can set a circular or rectangular sprite with
+  * different dimensions and offset from the sprite's center.
   *
-  * There are three ways to call this method:
+  * There are four ways to call this method:
   *
-  * 1. setCollider("rectangle", offsetX, offsetY, width, height)
-  * 2. setCollider("circle", offsetX, offsetY, radius)
-  * 3. setCollider("circle") - will use no offset and guess radius
+  * 1. setCollider("rectangle")
+  * 2. setCollider("rectangle", offsetX, offsetY, width, height)
+  * 3. setCollider("circle")
+  * 4. setCollider("circle", offsetX, offsetY, radius)
   *
   * @method setCollider
   * @param {String} type Either "rectangle" or "circle"

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -290,4 +290,93 @@ describe('Sprite', function() {
       });
     });
   });
+
+  describe('setCollider()', function() {
+    var sprite;
+
+    beforeEach(function() {
+      // Position: (10, 20), Size: (30, 40)
+      sprite = pInst.createSprite(10, 20, 30, 40);
+    });
+
+    it('a newly-created sprite has no collider', function() {
+      expect(sprite.collider).to.be.undefined;
+    });
+
+    it('throws if first argument is not "circle" or "rectangle"', function() {
+      // Also throws if undefined
+      expect(function() {
+        sprite.setCollider();
+      }).to.throw(TypeError, 'setCollider expects the first argument to be either "circle" or "rectangle"');
+
+      // Note, it's case-sensitive
+      expect(function() {
+        sprite.setCollider('CIRCLE');
+      }).to.throw(TypeError, 'setCollider expects the first argument to be either "circle" or "rectangle"');
+    });
+
+    it('can construct a circle collider with default radius and offset', function() {
+      sprite.setCollider('circle');
+      expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
+      expect(sprite.collider.center).to.eq(sprite.position);
+      expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.offset.x).to.eq(0);
+      expect(sprite.collider.offset.y).to.eq(0);
+      // Radius should be half of sprite's larger dimension.
+      expect(sprite.collider.radius).to.eq(20);
+    });
+
+    it('can construct a circle collider with explicit radius and offset', function() {
+      sprite.setCollider('circle', 1, 2, 3);
+      expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
+      expect(sprite.collider.center).to.eq(sprite.position);
+      expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.offset.x).to.eq(1);
+      expect(sprite.collider.offset.y).to.eq(2);
+      expect(sprite.collider.radius).to.eq(3);
+    });
+
+    it('throws if creating a circle collider with 1, 2, or 4+ params', function() {
+      expect(function() {
+        sprite.setCollider('circle', 1);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+      expect(function() {
+        sprite.setCollider('circle', 1, 2);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+      // setCollider('circle', 1, 2, 3) is fine
+      expect(function() {
+        sprite.setCollider('circle', 1, 2, 3, 4);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+      expect(function() {
+        sprite.setCollider('circle', 1, 2, 3, 4, 5);
+      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+    });
+
+    it('can construct a rectangle collider with explicit dimensions and offset', function() {
+      sprite.setCollider('rectangle', 1, 2, 3, 4);
+      expect(sprite.collider).to.be.an.instanceOf(pInst.AABB);
+    });
+
+    it('throws if creating a rectangle collider with 0, 1, 2, 3, or 5+ params', function() {
+      expect(function() {
+        sprite.setCollider('rectangle');
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2, 3);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      // setCollider('rectangle', 1, 2, 3, 4) is fine.
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2, 3, 4, 5);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(function() {
+        sprite.setCollider('rectangle', 1, 2, 3, 4, 5, 6);
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+    });
+  });
 });

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -320,11 +320,17 @@ describe('Sprite', function() {
       expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
       expect(sprite.collider.center).to.eq(sprite.position);
       // Radius should be half of sprite's larger dimension.
-      expect(sprite.collider.radius).to.eq(20);
+      expect(sprite.collider.radius).to.eq(sprite.height / 2);
       // Offset should be zero
       expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
       expect(sprite.collider.offset.x).to.eq(0);
       expect(sprite.collider.offset.y).to.eq(0);
+    });
+
+    it('scaling sprite without animation does not affect default circle collider size', function() {
+      sprite.scale = 0.25;
+      sprite.setCollider('circle');
+      expect(sprite.collider.radius).to.eq(sprite.height / 2);
     });
 
     it('can construct a circle collider with explicit radius and offset', function() {
@@ -367,7 +373,12 @@ describe('Sprite', function() {
       expect(sprite.collider.offset.y).to.eq(0);
     });
 
-    // TODO: Test with scaled sprite, make sure scale works as expected
+    it('scaling sprite without animation does not affect default rectangle collider size', function() {
+      sprite.scale = 0.25;
+      sprite.setCollider('rectangle');
+      expect(sprite.collider.extents.x).to.eq(sprite.width);
+      expect(sprite.collider.extents.y).to.eq(sprite.height);
+    });
 
     it('can construct a rectangle collider with explicit dimensions and offset', function() {
       sprite.setCollider('rectangle', 1, 2, 3, 4);

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -384,20 +384,20 @@ describe('Sprite', function() {
     it('throws if creating a rectangle collider with 1, 2, 3, or 5+ params', function() {
       expect(function() {
         sprite.setCollider('rectangle', 1);
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
       expect(function() {
         sprite.setCollider('rectangle', 1, 2);
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
       expect(function() {
         sprite.setCollider('rectangle', 1, 2, 3);
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
       // setCollider('rectangle', 1, 2, 3, 4) is fine.
       expect(function() {
         sprite.setCollider('rectangle', 1, 2, 3, 4, 5);
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
       expect(function() {
         sprite.setCollider('rectangle', 1, 2, 3, 4, 5, 6);
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+      }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
     });
   });
 });

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -319,11 +319,12 @@ describe('Sprite', function() {
       sprite.setCollider('circle');
       expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
       expect(sprite.collider.center).to.eq(sprite.position);
+      // Radius should be half of sprite's larger dimension.
+      expect(sprite.collider.radius).to.eq(20);
+      // Offset should be zero
       expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
       expect(sprite.collider.offset.x).to.eq(0);
       expect(sprite.collider.offset.y).to.eq(0);
-      // Radius should be half of sprite's larger dimension.
-      expect(sprite.collider.radius).to.eq(20);
     });
 
     it('can construct a circle collider with explicit radius and offset', function() {
@@ -331,9 +332,9 @@ describe('Sprite', function() {
       expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
       expect(sprite.collider.center).to.eq(sprite.position);
       expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.radius).to.eq(3);
       expect(sprite.collider.offset.x).to.eq(1);
       expect(sprite.collider.offset.y).to.eq(2);
-      expect(sprite.collider.radius).to.eq(3);
     });
 
     it('throws if creating a circle collider with 1, 2, or 4+ params', function() {
@@ -352,15 +353,35 @@ describe('Sprite', function() {
       }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
     });
 
+    it('can construct a rectangle collider with default dimensions and offset', function() {
+      sprite.setCollider('rectangle');
+      expect(sprite.collider).to.be.an.instanceOf(pInst.AABB);
+      expect(sprite.collider.center).to.eq(sprite.position);
+      // Extents should be sprite dimensions
+      expect(sprite.collider.extents).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.extents.x).to.eq(sprite.width);
+      expect(sprite.collider.extents.y).to.eq(sprite.height);
+      // Offset should be zero
+      expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.offset.x).to.eq(0);
+      expect(sprite.collider.offset.y).to.eq(0);
+    });
+
+    // TODO: Test with scaled sprite, make sure scale works as expected
+
     it('can construct a rectangle collider with explicit dimensions and offset', function() {
       sprite.setCollider('rectangle', 1, 2, 3, 4);
       expect(sprite.collider).to.be.an.instanceOf(pInst.AABB);
+      expect(sprite.collider.center).to.eq(sprite.position);
+      expect(sprite.collider.extents).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.extents.x).to.eq(3);
+      expect(sprite.collider.extents.y).to.eq(4);
+      expect(sprite.collider.offset).to.be.an.instanceOf(p5.Vector);
+      expect(sprite.collider.offset.x).to.eq(1);
+      expect(sprite.collider.offset.y).to.eq(2);
     });
 
-    it('throws if creating a rectangle collider with 0, 1, 2, 3, or 5+ params', function() {
-      expect(function() {
-        sprite.setCollider('rectangle');
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');
+    it('throws if creating a rectangle collider with 1, 2, 3, or 5+ params', function() {
       expect(function() {
         sprite.setCollider('rectangle', 1);
       }).to.throw(TypeError, 'Usage: setCollider("rectangle", offsetX, offsetY, width, height)');


### PR DESCRIPTION
Allow `setCollider("rectangle")` with no additional parameters, which creates a collider of the sprite's width and height with no offset.

This is similar, but not exactly like the `setDefaultCollider()` behavior - it expects the sprite's `width` and `height` to be correct (rather than sometimes retrieving them from the animation), and sets the 'custom' collider type which prevents certain automatic collider updates later on.

Depends on https://github.com/molleindustria/p5.play/pull/112 which introduced `setCollider("circle")`; you can ignore commit b1558a0.
