### PR TITLE
Flip friction value

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -827,14 +827,15 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
   /**
   * Friction factor, reduces the sprite's velocity.
-  * The friction should be close to 1 (eg. 0.99)
-  * 1: no friction
+  * The friction should be close to 0 (eg. 0.01)
+  * 0: no friction
+  * 1: full friction
   *
   * @property friction
   * @type {Number}
-  * @default 1
+  * @default 0
   */
-  this.friction = 1;
+  this.friction = 0;
 
   /**
   * The sprite's current collider.
@@ -1251,8 +1252,8 @@ function Sprite(pInst, _x, _y, _w, _h) {
       else
         this.previousPosition = createVector(this.position.x, this.position.y);
 
-      this.velocity.x *= this.friction;
-      this.velocity.y *= this.friction;
+      this.velocity.x *= 1 - this.friction;
+      this.velocity.y *= 1 - this.friction;
 
       if(this.maxSpeed !== -1)
         this.limitSpeed(this.maxSpeed);

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -419,19 +419,19 @@ describe('Sprite', function() {
       sprite = pInst.createSprite();
     });
 
-    it('has no effect on update() when set to 1', function() {
+    it('has no effect on update() when set to 0', function() {
       sprite.velocity.x = 1;
       sprite.velocity.y = 1;
-      sprite.friction = 1;
+      sprite.friction = 0;
       sprite.update();
       expect(sprite.velocity.x).to.equal(1);
       expect(sprite.velocity.y).to.equal(1);
     });
 
-    it('reduces velocity to zero on update() when set to 0', function() {
+    it('reduces velocity to zero on update() when set to 1', function() {
       sprite.velocity.x = 1;
       sprite.velocity.y = 1;
-      sprite.friction = 0;
+      sprite.friction = 1;
       sprite.update();
       expect(sprite.velocity.x).to.equal(0);
       expect(sprite.velocity.y).to.equal(0);
@@ -453,8 +453,8 @@ describe('Sprite', function() {
         expect(sprite.velocity.x).to.equal(2);
       });
 
-      it('cuts velocity to one-quarter each update when set to 0.25', function() {
-        sprite.friction = 0.25;
+      it('cuts velocity to one-quarter each update when set to 0.75', function() {
+        sprite.friction = 0.75;
         expect(sprite.velocity.x).to.equal(16);
         sprite.update();
         expect(sprite.velocity.x).to.equal(4);
@@ -490,8 +490,8 @@ describe('Sprite', function() {
         expect(sprite.velocity.mag()).to.equal(5 * 2);
       });
 
-      it('cuts velocity to one-quarter each update when set to 0.25', function() {
-        sprite.friction = 0.25;
+      it('cuts velocity to one-quarter each update when set to 0.75', function() {
+        sprite.friction = 0.75;
         expect(sprite.velocity.x).to.equal(3 * 16);
         expect(sprite.velocity.y).to.equal(4 * 16);
         expect(sprite.velocity.mag()).to.equal(5 * 16);

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -411,4 +411,103 @@ describe('Sprite', function() {
       }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
     });
   });
+
+  describe('friction', function() {
+    var sprite;
+
+    beforeEach(function() {
+      sprite = pInst.createSprite();
+    });
+
+    it('has no effect on update() when set to 1', function() {
+      sprite.velocity.x = 1;
+      sprite.velocity.y = 1;
+      sprite.friction = 1;
+      sprite.update();
+      expect(sprite.velocity.x).to.equal(1);
+      expect(sprite.velocity.y).to.equal(1);
+    });
+
+    it('reduces velocity to zero on update() when set to 0', function() {
+      sprite.velocity.x = 1;
+      sprite.velocity.y = 1;
+      sprite.friction = 0;
+      sprite.update();
+      expect(sprite.velocity.x).to.equal(0);
+      expect(sprite.velocity.y).to.equal(0);
+    });
+
+    describe('axis-aligned', function() {
+      beforeEach(function() {
+        sprite.velocity.x = 16;
+      });
+
+      it('cuts velocity in half each update when set to 0.5', function() {
+        sprite.friction = 0.5;
+        expect(sprite.velocity.x).to.equal(16);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(8);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(4);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(2);
+      });
+
+      it('cuts velocity to one-quarter each update when set to 0.25', function() {
+        sprite.friction = 0.25;
+        expect(sprite.velocity.x).to.equal(16);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(4);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(1);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(0.25);
+      });
+    });
+
+    describe('not axis-aligned', function() {
+      beforeEach(function() {
+        sprite.velocity.x = 3 * 16;
+        sprite.velocity.y = 4 * 16;
+      });
+
+      it('cuts velocity in half each update when set to 0.5', function() {
+        sprite.friction = 0.5;
+        expect(sprite.velocity.x).to.equal(3 * 16);
+        expect(sprite.velocity.y).to.equal(4 * 16);
+        expect(sprite.velocity.mag()).to.equal(5 * 16);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(3 * 8);
+        expect(sprite.velocity.y).to.equal(4 * 8);
+        expect(sprite.velocity.mag()).to.equal(5 * 8);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(3 * 4);
+        expect(sprite.velocity.y).to.equal(4 * 4);
+        expect(sprite.velocity.mag()).to.equal(5 * 4);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(3 * 2);
+        expect(sprite.velocity.y).to.equal(4 * 2);
+        expect(sprite.velocity.mag()).to.equal(5 * 2);
+      });
+
+      it('cuts velocity to one-quarter each update when set to 0.25', function() {
+        sprite.friction = 0.25;
+        expect(sprite.velocity.x).to.equal(3 * 16);
+        expect(sprite.velocity.y).to.equal(4 * 16);
+        expect(sprite.velocity.mag()).to.equal(5 * 16);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(3 * 4);
+        expect(sprite.velocity.y).to.equal(4 * 4);
+        expect(sprite.velocity.mag()).to.equal(5 * 4);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(3 * 1);
+        expect(sprite.velocity.y).to.equal(4 * 1);
+        expect(sprite.velocity.mag()).to.equal(5 * 1);
+        sprite.update();
+        expect(sprite.velocity.x).to.equal(3 * 0.25);
+        expect(sprite.velocity.y).to.equal(4 * 0.25);
+        expect(sprite.velocity.mag()).to.equal(5 * 0.25);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Proposed breaking change: Reverse the meaning and default value of the Sprite `friction` property so that zero means 'no friction' and 1 means 'full friction.'

Suggested by @molleindustria in https://github.com/molleindustria/p5.play/pull/114#issuecomment-254623761, and I agree this is more intuitive.
# New Tests

```
  Sprite
    friction
      ✓ has no effect on update() when set to 0 
      ✓ reduces velocity to zero on update() when set to 1 
      axis-aligned
        ✓ cuts velocity in half each update when set to 0.5 
        ✓ cuts velocity to one-quarter each update when set to 0.75 
      not axis-aligned
        ✓ cuts velocity in half each update when set to 0.5 
        ✓ cuts velocity to one-quarter each update when set to 0.75 
```
