### PR TITLE
Implement Sprite.displace in terms of Sprite.collide

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2329,13 +2329,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
             {
               var newVelX1, newVelY1, newVelX2, newVelY2;
 
-              if(!this.immovable)
-              {
-                if (type === 'displace') {
-                  other.position.sub(displacement);
-                } else {
-                  this.position.add(displacement);
-                }
+              if (type === 'displace' && !other.immovable) {
+                other.position.sub(displacement);
+              } else if ((type === 'collide' || type === 'bounce') && !this.immovable) {
+                this.position.add(displacement);
                 this.previousPosition = createVector(this.position.x, this.position.y);
                 this.newPosition = createVector(this.position.x, this.position.y);
               }

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -2256,7 +2256,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
                 callback.call(this, this, other);
             }
           }
-        else if(type === 'collide' || type === 'bounce')
+        else if(type === 'collide' || type === 'displace' || type === 'bounce')
           {
             displacement = createVector(0, 0);
 
@@ -2331,7 +2331,11 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
               if(!this.immovable)
               {
-                this.position.add(displacement);
+                if (type === 'displace') {
+                  other.position.sub(displacement);
+                } else {
+                  this.position.add(displacement);
+                }
                 this.previousPosition = createVector(this.position.x, this.position.y);
                 this.newPosition = createVector(this.position.x, this.position.y);
               }
@@ -2416,38 +2420,6 @@ function Sprite(pInst, _x, _y, _w, _h) {
               }
               //else if(type == "collide")
                 //this.velocity = createVector(0,0);
-
-              if(callback !== undefined && typeof callback === 'function')
-                callback.call(this, this, other);
-
-              result = true;
-            }
-
-
-
-          }
-          else if(type === 'displace') {
-
-            //if the other is a circle I calculate the displacement from here
-            //and reverse it
-            if(this.collider instanceof CircleCollider)
-              displacement = other.collider.collide(this.collider).mult(-1);
-            else
-              displacement = this.collider.collide(other.collider);
-
-
-            if(displacement.x !== 0 || displacement.y !== 0 )
-            {
-              other.position.sub(displacement);
-
-              if(displacement.x > 0)
-                this.touching.left = true;
-              if(displacement.x < 0)
-                this.touching.right = true;
-              if(displacement.y < 0)
-                this.touching.bottom = true;
-              if(displacement.y > 0)
-                this.touching.top = true;
 
               if(callback !== undefined && typeof callback === 'function')
                 callback.call(this, this, other);

--- a/test/unit/collisions/sprite-collide.js
+++ b/test/unit/collisions/sprite-collide.js
@@ -10,6 +10,7 @@
  * tests the behavior of the collide() method between two sprites.
  */
 describe('sprite.collide(sprite)', function() {
+  var expectVectorsAreClose = p5PlayAssertions.expectVectorsAreClose;
   var SIZE = 10;
   var pInst;
   var spriteA, spriteB;
@@ -181,11 +182,4 @@ describe('sprite.collide(sprite)', function() {
     expect(spriteA.velocity).to.deep.equal(initialVelocityA);
     expect(spriteB.velocity).to.deep.equal(initialVelocityB);
   });
-
-  function expectVectorsAreClose(vA, vB) {
-    var failMsg = 'Expected <' + vA.x + ', ' + vA.y + '> to equal <' +
-      vB.x + ', ' + vB.y + '>';
-    expect(vA.x).to.be.closeTo(vB.x, 0.00001, failMsg);
-    expect(vA.y).to.be.closeTo(vB.y, 0.00001, failMsg);
-  }
 });

--- a/test/unit/collisions/sprite-collide.js
+++ b/test/unit/collisions/sprite-collide.js
@@ -115,6 +115,19 @@ describe('sprite.collide(sprite)', function() {
     expect(spriteB.position).to.deep.equal(initialPositionB);
   });
 
+  it('does not reposition either sprite when caller is immovable', function() {
+    spriteA.position.x = spriteB.position.x - 1;
+    spriteA.immovable = true;
+
+    var initialPositionA = spriteA.position.copy();
+    var initialPositionB = spriteB.position.copy();
+
+    spriteA.collide(spriteB);
+
+    expectVectorsAreClose(spriteA.position, initialPositionA);
+    expectVectorsAreClose(spriteB.position, initialPositionB);
+  });
+
   describe('displaces the caller out of collision when sprites do overlap', function() {
     it('to the left', function() {
       spriteA.position.x = spriteB.position.x - 1;
@@ -168,4 +181,11 @@ describe('sprite.collide(sprite)', function() {
     expect(spriteA.velocity).to.deep.equal(initialVelocityA);
     expect(spriteB.velocity).to.deep.equal(initialVelocityB);
   });
+
+  function expectVectorsAreClose(vA, vB) {
+    var failMsg = 'Expected <' + vA.x + ', ' + vA.y + '> to equal <' +
+      vB.x + ', ' + vB.y + '>';
+    expect(vA.x).to.be.closeTo(vB.x, 0.00001, failMsg);
+    expect(vA.y).to.be.closeTo(vB.y, 0.00001, failMsg);
+  }
 });

--- a/test/unit/collisions/sprite-displace.js
+++ b/test/unit/collisions/sprite-displace.js
@@ -107,6 +107,19 @@ describe('sprite.displace(sprite)', function() {
     expectVectorsAreClose(spriteB.position, initialPositionB);
   });
 
+  it('does not reposition either sprite when callee is immovable', function() {
+    spriteA.position.x = spriteB.position.x - 1;
+    spriteB.immovable = true;
+
+    var initialPositionA = spriteA.position.copy();
+    var initialPositionB = spriteB.position.copy();
+
+    spriteA.displace(spriteB);
+
+    expectVectorsAreClose(spriteA.position, initialPositionA);
+    expectVectorsAreClose(spriteB.position, initialPositionB);
+  });
+
   describe('displaces the callee out of collision when sprites do overlap', function() {
     it('to the left', function() {
       spriteA.position.x = spriteB.position.x - 1;
@@ -145,10 +158,11 @@ describe('sprite.displace(sprite)', function() {
     });
   });
 
-  it('does not change velocity of either sprite when sprites do not overlap', function() {
+  it('does not change velocity of either sprite', function() {
     var initialVelocityA = spriteA.velocity.copy();
     var initialVelocityB = spriteB.velocity.copy();
 
+    spriteA.position.x = spriteB.position.x + 1;
     spriteA.displace(spriteB);
 
     expectVectorsAreClose(spriteA.velocity, initialVelocityA);


### PR DESCRIPTION
Removes the special case for `Sprite.displace` in `Sprite.AABBops` and instead implements it with a small change to the `Sprite.collide` path.

Built on top of https://github.com/molleindustria/p5.play/pull/116; it's probably easiest to [view the last three commits](https://github.com/molleindustria/p5.play/compare/bc3f7705bd38b014285fdb32911118355e18e06e...10990df158244f1dcb9e348de41c97d1e129c3ab).

Although more aggressive collision changes are on the way, I thought it'd be nice to clean up this bit of duplication on its own, because it will simplify future changes and makes the existing code easier to understand.

I believe there is exactly one behavior change in the PR: Where `displace` used to ignore the `immovable` flag (an undocumented, and probably unintentional, behavior) it now respects it, like `collide` does.  That is to say, just like `a.collide(b)` moves neither sprite when `a` is immovable, now `a.displace(b)` moves neither sprite when `b` is immovable.
