### PR TITLE
In docs, fix filtering class table of contents by member access

### DIFF
--- a/theme/assets/js/yuidoc-bootstrap.js
+++ b/theme/assets/js/yuidoc-bootstrap.js
@@ -62,7 +62,7 @@ $(function() {
         var cssName = $.trim(box.parent('label').text()).toLowerCase();
         if(box.is(':checked')){
             $('div.'+cssName).css('display', 'block');
-            $('li.'+cssName).css('display', 'block');
+            $('li.'+cssName).css('display', 'list-item');
             $('span.'+cssName).css('display', 'inline');
         }else{
             $('.'+cssName).css('display', 'none');

--- a/theme/partials/classes.handlebars
+++ b/theme/partials/classes.handlebars
@@ -68,7 +68,7 @@
 				{{#methods}}
 				{{#if static}}
 				{{else}}
-				<li><a href="#method-{{name}}"><span class="im">{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
+				<li class="{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}"><a href="#method-{{name}}"><span class="im">{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
 				{{/if}}
 				{{/methods}}
 			</ul>
@@ -80,7 +80,7 @@
 			<strong>Properties</strong>
 			<ul>
 				{{#properties}}
-				<li><a href="#prop-{{name}}"><span class="ip">{{name}}</span></a></li>
+				<li class="{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}"><a href="#prop-{{name}}"><span class="ip">{{name}}</span></a></li>
 				{{/properties}}
 			</ul>
 		</li>
@@ -91,7 +91,7 @@
 			<strong>Attributes</strong>
 			<ul>
 				{{#attrs}}
-				<li><a href="#attr-{{name}}"><span class="iattr">{{name}}</span></a></li>
+				<li class="{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}"><a href="#attr-{{name}}"><span class="iattr">{{name}}</span></a></li>
 				{{/attrs}}
 			</ul>
 		</li>
@@ -103,7 +103,7 @@
 			<ul>
 				{{#methods}}
 				{{#if static}}
-				<li><a href="#method-{{name}}"><span class="im">{{class}}.{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
+				<li class="{{#if access}} {{access}}{{/if}}{{#if deprecated}} deprecated{{/if}}{{#if extended_from}} inherited{{/if}}"><a href="#method-{{name}}"><span class="im">{{class}}.{{name}}</span>({{#params}}<span class="ia">{{name}}</span>{{/params}})</a></li>
 				{{/if}}
 				{{/methods}}
 			</ul>


### PR DESCRIPTION
I figured it out!

![out](https://cloud.githubusercontent.com/assets/1615761/19788410/dddf31c6-9c5c-11e6-8cb6-3f1cd555e12a.gif)

Entries in the table of contents on class pages now show/hide with the options checkboxes just like the actual entries do.

Now I won't feel so bad documenting private methods.
