### PR TITLE
Fix spritesheets

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3515,9 +3515,7 @@ function Animation(pInst) {
   else if (frameArguments.length === 1 && (frameArguments[0] instanceof SpriteSheet))
   {
     this.spriteSheet = frameArguments[0];
-    this.images = this.spriteSheet.frames.map( function(f) {
-      return f.frame;
-    });
+    this.images = this.spriteSheet.frames;
   }
   else if(frameArguments.length !== 0)//arbitrary list of images
   {
@@ -3592,7 +3590,7 @@ function Animation(pInst) {
       if(this.images[frame] !== undefined)
       {
         if (this.spriteSheet) {
-          var frame_info = this.images[frame];
+          var frame_info = this.images[frame].frame;
           pInst.image(this.spriteSheet.image, frame_info.x, frame_info.y, frame_info.width,
             frame_info.height, this.offX, this.offY, frame_info.width, frame_info.height);
         } else {
@@ -3800,8 +3798,11 @@ function Animation(pInst) {
   * @return {Number} Frame width
   */
   this.getWidth = function() {
-    if (this.images[frame]) {
+    if (this.images[frame] instanceof p5.Image) {
       return this.images[frame].width;
+    } else if (this.images[frame]) {
+      // Special case: Animation-from-spritesheet treats its images array differently.
+      return this.images[frame].frame.width;
     } else {
       return 1;
     }
@@ -3815,8 +3816,11 @@ function Animation(pInst) {
   * @return {Number} Frame height
   */
   this.getHeight = function() {
-    if (this.images[frame]) {
+    if (this.images[frame] instanceof p5.Image) {
       return this.images[frame].height;
+    } else if (this.images[frame]) {
+      // Special case: Animation-from-spritesheet treats its images array differently.
+      return this.images[frame].frame.height;
     } else {
       return 1;
     }

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,7 @@
     </script>
     <script src="../examples/lib/p5.js"></script>
     <script src="../lib/p5.play.js"></script>
+    <script src="unit/animation.js"></script>
     <script src="unit/collisions.js"></script>
     <script src="unit/group.js"></script>
     <script src="unit/input.js"></script>

--- a/test/unit/animation.js
+++ b/test/unit/animation.js
@@ -1,0 +1,43 @@
+describe('Animation', function() {
+  var pInst;
+
+  beforeEach(function() {
+    pInst = new p5(function() {
+    });
+  });
+
+  afterEach(function() {
+    pInst.remove();
+  });
+
+  it('gets created properly from a sequence of images', function() {
+    // Spritesheet example: 4x2 grid of 10x12 frames
+    var animation = pInst.loadAnimation('fakeImage0001.png', 'fakeImage0005.png');
+    // These images will fail to load but we can still assert some things about
+    // the internal structure of the animation
+    expect(animation.images).to.have.length(5);
+    animation.images.forEach(function(image) {
+      expect(image).to.be.an.instanceOf(p5.Image);
+    });
+  });
+
+  it('gets created properly from a spritesheet', function() {
+    // Spritesheet example: 4x2 grid of 10x12 frames
+    var image = new p5.Image(40, 24, pInst);
+    var spritesheet = pInst.loadSpriteSheet(image, 10, 12, 8);
+    var animation = pInst.loadAnimation(spritesheet);
+    expect(animation.spriteSheet).to.equal(spritesheet);
+    // Special case for spritesheet: The images array is this nested object,
+    // instead of an array of p5.Image like it is in other cases.
+    expect(animation.images).to.deep.equal([
+      {name: 0, frame: {x: 0, y: 0, width: 10, height: 12}},
+      {name: 1, frame: {x: 10, y: 0, width: 10, height: 12}},
+      {name: 2, frame: {x: 20, y: 0, width: 10, height: 12}},
+      {name: 3, frame: {x: 30, y: 0, width: 10, height: 12}},
+      {name: 4, frame: {x: 0, y: 12, width: 10, height: 12}},
+      {name: 5, frame: {x: 10, y: 12, width: 10, height: 12}},
+      {name: 6, frame: {x: 20, y: 12, width: 10, height: 12}},
+      {name: 7, frame: {x: 30, y: 12, width: 10, height: 12}},
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #125, supercedes #126.

This bug arises from a bizarre behavior in the `Animation` class, which can be constructed in (at least) three different ways:

* A: With a list of images `new Animation(pInst, image1, image2, image3)`
* B: With a range of images `new Animation(pInst, 'image0001.png', 'image0005.png')`
* C: With a spritesheet `new Animation(pInst, spritesheet)`

Unfortunately the internal structure of the `Animation` changes depending on how it was constructed.  In cases A and B, `this.images` is an array of `p5.Image` objects.  In case C, `this.images` is an array of POJOs in the form `{name: <string|number>, frame: {x: <number>, y: <number>, width: <number>, height: <number>}}`.

This becomes a problem when, for example, you want the width of the current frame.  In cases A and B you would ask for `this.images[current].width`, but in case C you have to ask for `this.images[current].frame.width`.

The change in #99 that introduced the spritesheet regression was a first attempt to unify these internal models, but they obviously missed a lot.  This change puts things back, fixes width/height accesses, and adds some basic tests for the interanl structure of `Animation` in different cases just to demonstrate the odd behavior.

Thanks @gtoast for finding this and the quick fix proposal, @SnipedCode for being the squeaky wheel!