### PR TITLE
Fix spritesheets position and offset

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3564,8 +3564,8 @@ function Animation(pInst) {
       {
         if (this.spriteSheet) {
           var frame_info = this.images[frame].frame;
-          pInst.image(this.spriteSheet.image, frame_info.x, frame_info.y, frame_info.width,
-            frame_info.height, this.offX, this.offY, frame_info.width, frame_info.height);
+          pInst.image(this.spriteSheet.image, this.offX, this.offY, frame_info.width,
+            frame_info.height, frame_info.x, frame_info.y, frame_info.width, frame_info.height);
         } else {
           pInst.image(this.images[frame], this.offX, this.offY);
         }


### PR DESCRIPTION
npm run test throws following errors - but they do not seem related to the change:

group.bounce(group)
Error loading resource file:///Users/me/devel/p5.play/test/fakeImage0001.png

Example sketches
    ◦ animation.js runs for 3 frames: You just changed the value of "camera", which was a p5 function. This could cause problems later if you're not careful.

collisions.js runs for 3 frames: p5 had problems creating the global function "box", possibly because your code is already using that name as a variable. You may want to rename your variable to something else.