### PR TITLE
Support p5.js >= 0.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ before_script:
   - 'if [ "$P5_VERSION" ]; then npm install p5@$P5_VERSION && npm run link:p5; fi'
 
 env:
-  - P5_VERSION=0.5.0
-  - P5_VERSION=0.5.1
-  - P5_VERSION=0.5.2
-  #- P5_VERSION=0.5.3 Known issue
-  - P5_VERSION=0.5.4
+  - P5_VERSION=0.5.5
+  - P5_VERSION=0.5.6
+  - P5_VERSION=0.5.7
+  - P5_VERSION=0.5.8
+  - P5_VERSION=0.5.9
+  - P5_VERSION=0.5.10
+  - P5_VERSION=0.5.11
+  - P5_VERSION=latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can find examples and more information at [p5play.molleindustria.org][].
 
 p5.play provides a Sprite class to manage visual objects in 2D space and features such as animation support, basic collision detection and resolution, sprite grouping, helpers for mouse and keyboard interactions, and a virtual camera. 
 
-p5.play extends [p5.js][], a javascript library (and a community) that aims to make coding accessible for artists, designers, educators, and beginners. If you are not familiar with p5.js, you should start at [p5js.org/tutorials][].
+p5.play extends [p5.js][] (>=0.5.5), a javascript library (and a community) that aims to make coding accessible for artists, designers, educators, and beginners. If you are not familiar with p5.js, you should start at [p5js.org/tutorials][].
 
 ## Development
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3919,8 +3919,8 @@ function SpriteSheet(pInst) {
     }
     var dWidth = width || frameToDraw.width;
     var dHeight = height || frameToDraw.height;
-    pInst.image(this.image, frameToDraw.x, frameToDraw.y,
-      frameToDraw.width, frameToDraw.height, x, y, dWidth, dHeight);
+    pInst.image(this.image, x, y, frameToDraw.width, frameToDraw.height,
+      frameToDraw.x, frameToDraw.y, dWidth, dHeight);
   };
 
   /**

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3564,8 +3564,8 @@ function Animation(pInst) {
       {
         if (this.spriteSheet) {
           var frame_info = this.images[frame].frame;
-          pInst.image(this.spriteSheet.image, frame_info.x, frame_info.y, frame_info.width,
-            frame_info.height, this.offX, this.offY, frame_info.width, frame_info.height);
+          pInst.image(this.spriteSheet.image, this.offX, this.offY, frame_info.width,
+            frame_info.height, frame_info.x, frame_info.y, frame_info.width, frame_info.height);
         } else {
           pInst.image(this.images[frame], this.offX, this.offY);
         }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint": "^3.1.0",
     "http-server": "^0.9.0",
     "mocha-phantomjs": "^4.0.1",
-    "p5": "0.5 - 0.5.2 || 0.5.4",
+    "p5": "^0.5.5",
     "yuidocjs": "^0.10.0"
   },
   "engines": {

--- a/test/unit/examples.js
+++ b/test/unit/examples.js
@@ -1,6 +1,24 @@
 describe('Example sketches', function() {
   var FRAMES_TO_DRAW = 3;
 
+  // Examples we are unable to test in PhantomJS
+  var PHANTOMJS_BLACKLIST = [
+    // This example can't be tested in Phantom unit tests because it calls
+    // loadJSON() which uses the `fetch` API since p5.js@0.5.8 and won't permit
+    // loading a file from localhost.
+    // Maybe someday we can serve test files from a local server.
+    // This works fine when run in the browser from the local dev server.
+    // See also:
+    // https://github.com/processing/p5.js/issues/1975
+    // https://github.com/processing/p5.js/wiki/Local-server
+    'sprites_with_sheet.js'
+  ];
+
+  var inPhantomJS = (/PhantomJS/).test(window.navigator.userAgent);
+  function isBlacklisted(filename) {
+    return inPhantomJS && PHANTOMJS_BLACKLIST.indexOf(filename) >= 0;
+  }
+
   var iframe;
   var examples = (function findExamples() {
     var FILENAME_RE = /index\.html\?fileName=([A-Za-z0-9_.]+)/g;
@@ -52,7 +70,7 @@ describe('Example sketches', function() {
 
   examples.forEach(function(fileName) {
     var testName = fileName + ' runs for ' + FRAMES_TO_DRAW + ' frames';
-    it(testName, function(done) {
+    function testFunc(done) {
       var windowCbName = 'example_' + fileName.slice(0, -3) + '_done';
       var iframeScriptArgs = [
         windowCbName,
@@ -79,6 +97,12 @@ describe('Example sketches', function() {
         '<script src="' + fileName + '"></script>'
       ].join('\n'));
       iframe.contentDocument.close();
-    });
+    }
+
+    if (isBlacklisted(fileName)) {
+      it.skip(testName);
+    } else {
+      it(testName, testFunc);
+    }
   });
 });

--- a/test/unit/spritesheet.js
+++ b/test/unit/spritesheet.js
@@ -85,16 +85,16 @@ describe('SpriteSheet', function() {
       expect(pInst.image.calledOnce).to.be.true;
       expect(pInst.image.firstCall.calledWith(
         srcImage,         // source image
-        100, 0, 100, 160, // source coordinates
-        25, 45, 50, 80    // destination coordinates
+        25, 45, 100, 160, // source coordinates
+        100, 0, 50, 80    // destination coordinates
       )).to.be.true;
 
       sheet.drawFrame(0, 25, 45, 50, 80);
       expect(pInst.image.calledTwice).to.be.true;
       expect(pInst.image.secondCall.calledWith(
         srcImage,         // source image
-        0, 0, 100, 160,   // source coordinates
-        25, 45, 50, 80    // destination coordinates
+        25, 45, 100, 160, // source coordinates
+        0, 0, 50, 80      // destination coordinates
       )).to.be.true;
     });
 
@@ -102,8 +102,8 @@ describe('SpriteSheet', function() {
       sheet.drawFrame(2, 25, 45, 50, 80);
       expect(pInst.image.firstCall.calledWith(
         srcImage,         // source image
-        200, 0, 100, 160, // source coordinates
-        25, 45, 50, 80    // destination coordinates
+        25, 45, 100, 160, // source coordinates
+        200, 0, 50, 80    // destination coordinates
       )).to.be.true;
     });
 
@@ -111,8 +111,8 @@ describe('SpriteSheet', function() {
       sheet.drawFrame('happy', 25, 45, 50, 80);
       expect(pInst.image.firstCall.calledWith(
         srcImage,         // source image
-        200, 0, 100, 160, // source coordinates
-        25, 45, 50, 80    // destination coordinates
+        25, 45, 100, 160, // source coordinates
+        200, 0, 50, 80    // destination coordinates
       )).to.be.true;
     });
 
@@ -120,8 +120,8 @@ describe('SpriteSheet', function() {
       sheet.drawFrame(0, 25, 45);
       expect(pInst.image.firstCall.calledWith(
         srcImage,         // source image
-        0, 0, 100, 160,   // source coordinates
-        25, 45, 100, 160  // destination coordinates
+        25, 45, 100, 160, // source coordinates
+        0, 0, 100, 160    // destination coordinates
       )).to.be.true;
     });
   });


### PR DESCRIPTION
A [breaking change](https://github.com/processing/p5.js/issues/1653) ([commit](https://github.com/processing/p5.js/commit/6ac5bc00e101c739e1c423939294a8db51cf3210)) to the argument order of the `image()` function in p5.js 0.5.5 broke spritesheets in p5.play.  This PR makes p5.play compatible with p5.js 0.5.5-0.5.11 (latest as of now).  It _removes_ support for p5.js < 0.5.5; developers wishing to use older p5.js versions will need to use old p5.play versions as well.

Thanks to @cbsrobot and @cesarrodas for raising this issue in https://github.com/molleindustria/p5.play/pull/132 and https://github.com/molleindustria/p5.play/issues/136 respectively.  I've integrated #132 into this PR, replacing it, and this should resolve #136.

I've updated the test matrix to run unit tests against each p5.js version 0.5.5-0.5.11 and against the latest version as well to catch future changes.

I had to blacklist one of the examples from the unit test suite because it uses `loadJSON()`, which was reimplemented with `fetch` in p5.js@0.5.8 and now refuses to load JSON assets from `file://` URLs.  The behavior is not broken. That test still runs and passes when running the test suite in the browser - maybe soon we can update our test runner to run the suite from a local dev server.