### PR TITLE
Correct documentation for Animation.frameDelay

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -3337,12 +3337,12 @@ function Animation(pInst) {
 
   /**
   * Delay between frames in number of draw cycles.
-  * If set to 4 the framerate of the anymation would be the
+  * If set to 4 the framerate of the animation would be the
   * sketch framerate divided by 4 (60fps = 15fps)
   *
   * @property frameDelay
   * @type {Number}
-  * @default 2
+  * @default 4
   */
   this.frameDelay = 4;
 


### PR DESCRIPTION
Documentation-only change. Fixes issue #147.