### PR TITLE
Correct friction values in asteroids example

### DIFF
--- a/examples/asteroids.js
+++ b/examples/asteroids.js
@@ -16,7 +16,7 @@ function setup() {
 
   ship = createSprite(width/2, height/2);
   ship.maxSpeed = 6;
-  ship.friction = 0.98;
+  ship.friction = 0.02;
   ship.setCollider('circle', 0, 0, 20);
 
   ship.addImage('normal', shipImage);
@@ -109,7 +109,7 @@ function asteroidHit(asteroid, bullet) {
     var p = createSprite(bullet.position.x, bullet.position.y);
     p.addImage(particleImage);
     p.setSpeed(random(3, 5), random(360));
-    p.friction = 0.95;
+    p.friction = 0.05;
     p.life = 15;
   }
 


### PR DESCRIPTION
@BenjamintGibbs pointed out in https://github.com/molleindustria/p5.play/issues/152 that our asteroids example was not working properly: The ship would not move.  This is a regression I introduced in https://github.com/molleindustria/p5.play/pull/120 when we reversed the meaning of the Sprite friction property.  The solution is to pass corrected (inverted) friction values in the asteroids example.

The corresponding asteroids example running the background of the p5.play landing page is also broken.  I will fix that in https://github.com/molleindustria/p5.play/pull/150 before I merge that update.