### PR TITLE
Friendlier setCollider errors

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1506,8 +1506,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
   this.setCollider = function(type, offsetX, offsetY, width, height) {
     if (!(type === 'rectangle' || type === 'circle')) {
       throw new TypeError('setCollider expects the first argument to be either "circle" or "rectangle"');
-    } else if (type === 'circle' && !(arguments.length === 1 || arguments.length === 4)) {
+    } else if (type === 'circle' && arguments.length > 1 && arguments.length < 4) {
       throw new TypeError('Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+    } else if (type === 'circle' && arguments.length > 4) {
+      pInst._warn('Extra parameters to setCollider were ignored. Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
     } else if (type === 'rectangle' && !(arguments.length === 1 || arguments.length === 5)) {
       throw new TypeError('Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
     }
@@ -1521,7 +1523,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       this.collider = new AABB(pInst, this.position, createVector(width, height), v);
     } else if (type === 'circle' && arguments.length === 1) {
       this.collider = new CircleCollider(pInst, this.position, Math.floor(Math.max(this.width, this.height) / 2));
-    } else if (type === 'circle' && arguments.length === 4) {
+    } else if (type === 'circle' && arguments.length >= 4) {
       this.collider = new CircleCollider(pInst, this.position, width, v);
     }
 

--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -1510,8 +1510,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
       throw new TypeError('Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
     } else if (type === 'circle' && arguments.length > 4) {
       pInst._warn('Extra parameters to setCollider were ignored. Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
-    } else if (type === 'rectangle' && !(arguments.length === 1 || arguments.length === 5)) {
+    } else if (type === 'rectangle' && arguments.length > 1 && arguments.length < 5) {
       throw new TypeError('Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
+    } else if (type === 'rectangle' && arguments.length > 5) {
+      pInst._warn('Extra parameters to setCollider were ignored. Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
     }
 
     this.colliderType = 'custom';
@@ -1519,7 +1521,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
     var v = createVector(offsetX, offsetY);
     if (type === 'rectangle' && arguments.length === 1) {
       this.collider = new AABB(pInst, this.position, createVector(this.width, this.height));
-    } else if (type === 'rectangle' && arguments.length === 5) {
+    } else if (type === 'rectangle' && arguments.length >= 5) {
       this.collider = new AABB(pInst, this.position, createVector(width, height), v);
     } else if (type === 'circle' && arguments.length === 1) {
       this.collider = new CircleCollider(pInst, this.position, Math.floor(Math.max(this.width, this.height) / 2));

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -292,11 +292,20 @@ describe('Sprite', function() {
   });
 
   describe('setCollider()', function() {
-    var sprite;
+    var sprite, _warn;
 
     beforeEach(function() {
       // Position: (10, 20), Size: (30, 40)
       sprite = pInst.createSprite(10, 20, 30, 40);
+
+      // Stub p5.prototype._warn to hide console output during tests
+      // and allow sensing console output as needed.
+      _warn = sinon.stub(p5.prototype, '_warn');
+    });
+
+    afterEach(function() {
+      // Restore original p5.prototype._warn so we don't affect other tests.
+      _warn.restore();
     });
 
     it('a newly-created sprite has no collider', function() {
@@ -341,22 +350,30 @@ describe('Sprite', function() {
       expect(sprite.collider.radius).to.eq(3);
       expect(sprite.collider.offset.x).to.eq(1);
       expect(sprite.collider.offset.y).to.eq(2);
+      expect(_warn.callCount).to.equal(0);
     });
 
-    it('throws if creating a circle collider with 1, 2, or 4+ params', function() {
+    it('throws if creating a circle collider with 1 or 2 params', function() {
       expect(function() {
         sprite.setCollider('circle', 1);
       }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
       expect(function() {
         sprite.setCollider('circle', 1, 2);
       }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
-      // setCollider('circle', 1, 2, 3) is fine
-      expect(function() {
-        sprite.setCollider('circle', 1, 2, 3, 4);
-      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
-      expect(function() {
-        sprite.setCollider('circle', 1, 2, 3, 4, 5);
-      }).to.throw(TypeError, 'Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+    });
+
+    it('logs a warning and ignores extra params for circle collider', function() {
+      sprite.setCollider('circle', 1, 2, 3, 4);
+      expect(_warn.callCount).to.equal(1);
+      expect(_warn.firstCall.args[0]).to.equal('Extra parameters to setCollider were ignored. Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
+      expect(sprite.collider).to.be.an.instanceOf(pInst.CircleCollider);
+      expect(sprite.collider.offset.x).to.eq(1);
+      expect(sprite.collider.offset.y).to.eq(2);
+      expect(sprite.collider.radius).to.eq(3);
+
+      sprite.setCollider('circle', 1, 2, 3, 4, 5);
+      expect(_warn.callCount).to.equal(2);
+      expect(_warn.lastCall.args[0]).to.equal('Extra parameters to setCollider were ignored. Usage: setCollider("circle") or setCollider("circle", offsetX, offsetY, radius)');
     });
 
     it('can construct a rectangle collider with default dimensions and offset', function() {

--- a/test/unit/sprite.js
+++ b/test/unit/sprite.js
@@ -409,7 +409,7 @@ describe('Sprite', function() {
       expect(sprite.collider.offset.y).to.eq(2);
     });
 
-    it('throws if creating a rectangle collider with 1, 2, 3, or 5+ params', function() {
+    it('throws if creating a rectangle collider with 1, 2, or 3 params', function() {
       expect(function() {
         sprite.setCollider('rectangle', 1);
       }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
@@ -419,13 +419,21 @@ describe('Sprite', function() {
       expect(function() {
         sprite.setCollider('rectangle', 1, 2, 3);
       }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
-      // setCollider('rectangle', 1, 2, 3, 4) is fine.
-      expect(function() {
-        sprite.setCollider('rectangle', 1, 2, 3, 4, 5);
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
-      expect(function() {
-        sprite.setCollider('rectangle', 1, 2, 3, 4, 5, 6);
-      }).to.throw(TypeError, 'Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
+    });
+
+    it('logs a warning and ignores extra params for rectangle collider', function() {
+      sprite.setCollider('rectangle', 1, 2, 3, 4, 5);
+      expect(_warn.callCount).to.equal(1);
+      expect(_warn.firstCall.args[0]).to.equal('Extra parameters to setCollider were ignored. Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
+      expect(sprite.collider).to.be.an.instanceOf(pInst.AABB);
+      expect(sprite.collider.offset.x).to.eq(1);
+      expect(sprite.collider.offset.y).to.eq(2);
+      expect(sprite.collider.extents.x).to.eq(3);
+      expect(sprite.collider.extents.y).to.eq(4);
+
+      sprite.setCollider('rectangle', 1, 2, 3, 4, 5, 6);
+      expect(_warn.callCount).to.equal(2);
+      expect(_warn.lastCall.args[0]).to.equal('Extra parameters to setCollider were ignored. Usage: setCollider("rectangle") or setCollider("rectangle", offsetX, offsetY, width, height)');
     });
   });
 


### PR DESCRIPTION
In https://github.com/molleindustria/p5.play/issues/154 @lee2sman pointed out that passing a height parameter to `setCollider` (or really, any extra arguments to `setCollider`) throws an uncaught error.  This PR makes `setCollider` more forgiving - in case of extra arguments it will log a warning and proceed as if the extra arguments had not been provided.

`setCollider` still has a number of cases where it can throw errors by design, because it's got an exceedingly complicated signature. There are four ways to call this method (as [described in the docs](http://molleindustria.github.io/p5.play/docs/classes/Sprite.html#method-setCollider)):

```
setCollider("rectangle")
setCollider("rectangle", offsetX, offsetY, width, height)
setCollider("circle")
setCollider("circle", offsetX, offsetY, radius)
```

We still throw if the first argument is something other than `"circle"` or `"rectangle"`, or if the method is called with missing arguments.