### PR TITLE
fixed "Animation" keyword conflict

### DIFF
--- a/lib/p5.play.js
+++ b/lib/p5.play.js
@@ -291,7 +291,7 @@ p5.prototype.drawSprite = function(sprite) {
 * @param {Sprite} sprite Sprite to be displayed
 */
 p5.prototype.loadAnimation = function() {
-  return construct(this.Animation, arguments);
+  return construct(this.SpriteAnimation, arguments);
 };
 
 /**
@@ -308,7 +308,7 @@ p5.prototype.loadSpriteSheet = function() {
 * Displays an animation.
 *
 * @method animation
-* @param {Animation} anim Animation to be displayed
+* @param {SpriteAnimation} anim Animation to be displayed
 * @param {Number} x X coordinate
 * @param {Number} y Y coordinate
 *
@@ -1204,7 +1204,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * Reference to the current animation.
   *
   * @property animation
-  * @type {Animation}
+  * @type {SpriteAnimation}
   */
   this.animation = undefined;
 
@@ -1918,13 +1918,13 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * Usage:
   * - sprite.addAnimation(label, animation);
   *
-  * Alternative usages. See Animation for more information on file sequences:
+  * Alternative usages. See SpriteAnimation for more information on file sequences:
   * - sprite.addAnimation(label, firstFrame, lastFrame);
   * - sprite.addAnimation(label, frame1, frame2, frame3...);
   *
   * @method addAnimation
-  * @param {String} label Animation identifier
-  * @param {Animation} animation The preloaded animation
+  * @param {String} label SpriteAnimation identifier
+  * @param {SpriteAnimation} animation The preloaded animation
   */
   this.addAnimation = function(label)
   {
@@ -1940,7 +1940,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       print('addAnimation error: you must specify a label and n frame images');
       return -1;
     }
-    else if(arguments[1] instanceof Animation)
+    else if(arguments[1] instanceof SpriteAnimation)
     {
 
       var sourceAnimation = arguments[1];
@@ -1968,7 +1968,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
       for(var i=1; i<arguments.length; i++)
         animFrames.push(arguments[i]);
 
-      anim = construct(pInst.Animation, animFrames);
+      anim = construct(pInst.SpriteAnimation, animFrames);
       animations[label] = anim;
 
       if(currentAnimation === '')
@@ -1991,7 +1991,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * Equivalent to changeAnimation
   *
   * @method changeImage
-  * @param {String} label Image/Animation identifier
+  * @param {String} label Image/SpriteAnimation identifier
   */
   this.changeImage = function(label) {
     this.changeAnimation(label);
@@ -2001,7 +2001,7 @@ function Sprite(pInst, _x, _y, _w, _h) {
   * Returns the label of the current animation
   *
   * @method getAnimationLabel
-  * @return {String} label Image/Animation identifier
+  * @return {String} label Image/SpriteAnimation identifier
   */
   this.getAnimationLabel = function() {
     return currentAnimation;
@@ -2009,10 +2009,10 @@ function Sprite(pInst, _x, _y, _w, _h) {
 
   /**
   * Changes the displayed animation.
-  * See Animation for more control over the sequence.
+  * See SpriteAnimation for more control over the sequence.
   *
   * @method changeAnimation
-  * @param {String} label Animation identifier
+  * @param {String} label SpriteAnimation identifier
   */
   this.changeAnimation = function(label) {
     if(!animations[label])
@@ -3295,7 +3295,7 @@ defineLazyP5Property('AABB', boundConstructorFactory(AABB));
 
 
 /**
- * An Animation object contains a series of images (p5.Image) that
+ * An SpriteAnimation object contains a series of images (p5.Image) that
  * can be displayed sequentially.
  *
  * All files must be png images. You must include the directory from the sketch root,
@@ -3332,13 +3332,13 @@ defineLazyP5Property('AABB', boundConstructorFactory(AABB));
  *       animation(glitch, 200, 100);
  *     }
  *
- * @class Animation
+ * @class SpriteAnimation
  * @constructor
  * @param {String} fileName1 First file in a sequence OR first image file
  * @param {String} fileName2 Last file in a sequence OR second image file
  * @param {String} [...fileNameN] Any number of image files after the first two
  */
-function Animation(pInst) {
+function SpriteAnimation(pInst) {
   var frameArguments = Array.prototype.slice.call(arguments, 1);
   var i;
 
@@ -3422,14 +3422,14 @@ function Animation(pInst) {
     var ext1 = from.substring(from.length-4, from.length);
     if(ext1 !== '.png')
     {
-      pInst.print('Animation error: you need to use .png files (filename '+from+')');
+      pInst.print('SpriteAnimation error: you need to use .png files (filename '+from+')');
       from = -1;
     }
 
     var ext2 = to.substring(to.length-4, to.length);
     if(ext2 !== '.png')
     {
-      pInst.print('Animation error: you need to use .png files (filename '+to+')');
+      pInst.print('SpriteAnimation error: you need to use .png files (filename '+to+')');
       to = -1;
     }
 
@@ -3535,10 +3535,10 @@ function Animation(pInst) {
   * using the same animation you need to clone it.
   *
   * @method clone
-  * @return {Animation} A clone of the current animation
+  * @return {SpriteAnimation} A clone of the current animation
   */
   this.clone = function() {
-    var myClone = new Animation(pInst); //empty
+    var myClone = new SpriteAnimation(pInst); //empty
     myClone.images = [];
 
     if (this.spriteSheet) {
@@ -3695,7 +3695,7 @@ function Animation(pInst) {
   * fire when animation ends
   *
   * @method onComplete
-  * @return {Animation} 
+  * @return {SpriteAnimation} 
   */
   this.onComplete = function () {
     return undefined;
@@ -3848,10 +3848,10 @@ function Animation(pInst) {
 
 }
 
-defineLazyP5Property('Animation', boundConstructorFactory(Animation));
+defineLazyP5Property('SpriteAnimation', boundConstructorFactory(SpriteAnimation));
 
 /**
- * Represents a sprite sheet and all it's frames.  To be used with Animation,
+ * Represents a sprite sheet and all it's frames.  To be used with SpriteAnimation,
  * or static drawing single frames.
  *
  *  There are two different ways to load a SpriteSheet


### PR DESCRIPTION
I renamed the "Animation" class to "SpriteAnimation". All the the examples still seem to run fine. The "camera" conflict is still there, I plan to look at that next, but it only becomes an issue when you are wanting to use the P5.js "camera" function, whereas the "Animation" issue causes p5.play to stop working altogether.

Please accept this pull request or offer feedback on what needs to be changed. I understand this project may not be actively maintained but I would really love to contribute.