### PR TITLE
Fix `getSpritesAt` querying for only one fixture.

### DIFF
--- a/p5.play.js
+++ b/p5.play.js
@@ -3920,12 +3920,11 @@ p5.prototype.registerMethod('init', function p5PlayInit() {
 		aabb.upperBound = new pl.Vec2(convertedPoint.x + 0.001, convertedPoint.y + 0.001);
 
 		// Query the world for overlapping shapes.
-		let selectedFxt = null;
+		let fxts = [];
 		pInst.world.queryAABB(aabb, (fxt) => {
 			if (!fxt.getBody().isStatic()) {
 				if (fxt.getShape().testPoint(fxt.getBody().getTransform(), convertedPoint)) {
-					selectedFxt = fxt;
-					return false;
+					fxts.push(fxt);
 				}
 			}
 			return true;
@@ -3934,10 +3933,10 @@ p5.prototype.registerMethod('init', function p5PlayInit() {
 		group ??= pInst.allSprites;
 
 		let sprites = [];
-		if (selectedFxt) {
+		if (fxts.length > 0) {
 			for (let s of group) {
 				if (!s.body) continue;
-				if (selectedFxt == s.body.m_fixtureList) {
+				if ( fxts.includes(s.body.m_fixtureList) ) {
 					if (s._cameraActiveWhenDrawn == cameraActiveWhenDrawn) sprites.push(s);
 				}
 			}


### PR DESCRIPTION
`getSpritesAt` should not stop querying the world when one overlapping fixture is found, but should keep on querying for all overlapping fixtures.